### PR TITLE
Dockerfile: remove operator from release payload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY manifests /manifests
 RUN useradd cluster-storage-operator
 USER cluster-storage-operator
 ENTRYPOINT ["/usr/bin/cluster-storage-operator"]
-LABEL io.openshift.release.operator true
+
 LABEL io.k8s.display-name="OpenShift cluster-storage-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of cluster storage components." \
       maintainer="Matthew Wong <mawong@redhat.com>"


### PR DESCRIPTION
Please do not merge without green `e2e-aws` like here https://github.com/openshift/cluster-storage-operator/pull/2

An example is above where the crashlooping pod for this operator is preventing merges on other repos here:
https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/225/pull-ci-openshift-machine-config-operator-master-e2e-aws/618
```console
failed: (5m2s) 2018-12-09T20:36:19 "[Feature:Platform][Smoke] Managed cluster should start all core operators [Suite:openshift/conformance/parallel] [Suite:openshift/smoke-4]"
```
because
```console
sh-4.2$ oc -n openshift-cluster-storage-operator get all
NAME                                           READY     STATUS             RESTARTS   AGE
pod/cluster-storage-operator-6dd8c5774-v5std   0/1       CrashLoopBackOff   5          6m

NAME                                       DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cluster-storage-operator   1         1         1            0           6m

NAME                                                 DESIRED   CURRENT   READY     AGE
replicaset.apps/cluster-storage-operator-6dd8c5774   1         1         0         6m
sh-4.2$ oc -n openshift-cluster-storage-operator logs cluster-storage-operator-6dd8c5774-v5std
2018/12/09 20:29:38 Go Version: go1.10.3
2018/12/09 20:29:38 Go OS/Arch: linux/amd64
2018/12/09 20:29:38 operator-sdk Version: v0.1.0+git
2018/12/09 20:29:38 Registering Components.
2018/12/09 20:29:38 Starting the Cmd.
2018/12/09 20:29:38 Reconciling ConfigMap kube-system/cluster-config-v1
E1209 20:29:38.905427       1 runtime.go:66] Observed a panic: "asset: Asset(manifests/aws.yaml): Asset manifests/aws.yaml not found" (asset: Asset(manifests/aws.yaml): Asset manifests/aws.yaml not found)
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/asm_amd64.s:573
/usr/local/go/src/runtime/panic.go:502
/go/src/github.com/openshift/cluster-storage-operator/pkg/generated/bindata.go:132
/go/src/github.com/openshift/cluster-storage-operator/pkg/controller/clusterstorage/clusterstorage_controller.go:163
/go/src/github.com/openshift/cluster-storage-operator/pkg/controller/clusterstorage/clusterstorage_controller.go:127
/go/src/github.com/openshift/cluster-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:207
/go/src/github.com/openshift/cluster-storage-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:157
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134
/go/src/github.com/openshift/cluster-storage-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
/usr/local/go/src/runtime/asm_amd64.s:2361
panic: asset: Asset(manifests/aws.yaml): Asset manifests/aws.yaml not found [recovered]
        panic: asset: Asset(manifests/aws.yaml): Asset manifests/aws.yaml not found
```