### PR TITLE
version: Set the cluster operator version based on the payload

### DIFF
--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -29,6 +29,8 @@ spec:
           - cluster-storage-operator
           imagePullPolicy: IfNotPresent
           env:
+            - name: RELEASE_VERSION
+              value: "0.0.1-snapshot"
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/manifests/03-cluster-operator.yaml
+++ b/manifests/03-cluster-operator.yaml
@@ -2,4 +2,7 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: cluster-storage-operator
-  spec: {}
+status:
+  versions:
+  - name: operator
+    version: "0.0.1-snapshot"


### PR DESCRIPTION
The new contract with operators is that we report the version when
we reach "level" (have rolled out the version we got handed in the
payload) and are available, which ensures that the CVO can wait
until it sees us completely roll out the payload. This makes upgrade
status much clearer.

See https://github.com/openshift/cluster-image-registry-operator/pull/219 for more context, we are rolling this out across all operators.