### PR TITLE
Do not re-queue if error is unsupported

### DIFF
--- a/pkg/controller/clusterstorage/clusterstorage_controller.go
+++ b/pkg/controller/clusterstorage/clusterstorage_controller.go
@@ -151,7 +151,11 @@ func (r *ReconcileClusterStorage) Reconcile(request reconcile.Request) (reconcil
 	sc, err := newStorageClassForCluster(instance)
 	if err != nil {
 		_ = r.syncStatus(clusterOperatorInstance, err)
-		return reconcile.Result{}, err
+		// requeue only if platform is supported
+		if err != unsupportedPlatformError {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
 	}
 
 	// Set ConfigMap instance as the owner and controller


### PR DESCRIPTION
I think even though ClusterOperator is being created correctly, we need to stop the operation from requeing.  It should fix - https://github.com/openshift/cluster-storage-operator/issues/19

cc @wongma7 @bertinatto 