### PR TITLE
Bug 1751641: Enables updating of StorageClass if a change is detected.

### DIFF
--- a/pkg/controller/clusterstorage/clusterstorage_controller_test.go
+++ b/pkg/controller/clusterstorage/clusterstorage_controller_test.go
@@ -3,15 +3,19 @@ package clusterstorage
 import (
 	"context"
 	"os"
+	"reflect"
+	"strconv"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-storage-operator/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestSetStatusProgressing(t *testing.T) {
@@ -92,4 +96,114 @@ func TestSetStatusProgressing(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcile(t *testing.T) {
+
+	platform := configv1.AWSPlatformType
+
+	tests := []struct {
+		name                 string
+		existingStorageClass *storagev1.StorageClass
+		newStorageClass      *storagev1.StorageClass
+		expectedStorageClass *storagev1.StorageClass
+	}{
+		{
+			name:                 "StorageClass needs to be updated. Annotations must be kept intact.",
+			existingStorageClass: getFakeStorageClass(false, false, ""),
+			newStorageClass:      getFakeStorageClass(false, true, ""),
+			expectedStorageClass: getFakeStorageClass(true, false, "kubernetes.io/aws-ebs"),
+		},
+		{
+			name:                 "StorageClass matches and does not need to be updated",
+			existingStorageClass: getFakeStorageClass(true, true, "kubernetes.io/aws-ebs"),
+			newStorageClass:      getFakeStorageClass(true, true, "kubernetes.io/aws-ebs"),
+			expectedStorageClass: getFakeStorageClass(true, true, "kubernetes.io/aws-ebs"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clusterOperator := &configv1.ClusterOperator{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storage",
+					Namespace: corev1.NamespaceAll,
+				},
+			}
+			infrastructure := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storage",
+					Namespace: corev1.NamespaceAll,
+				},
+				Status: configv1.InfrastructureStatus{
+					Platform: platform,
+				},
+			}
+			scheme := runtime.NewScheme()
+			if err := apis.AddToScheme(scheme); err != nil {
+				t.Errorf("apis.AddToScheme: %v", err)
+			}
+			if err := configv1.AddToScheme(scheme); err != nil {
+				t.Errorf("configv1.AddToScheme: %v", err)
+			}
+			if err := storagev1.AddToScheme(scheme); err != nil {
+				t.Errorf("storagev1.AddToScheme: %v", err)
+			}
+			client := fake.NewFakeClientWithScheme(scheme, clusterOperator, test.existingStorageClass, infrastructure)
+			reconciler := &ReconcileClusterStorage{client: client, scheme: scheme}
+
+			request := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "storage",
+					Namespace: corev1.NamespaceAll,
+				},
+			}
+			_, err := reconciler.Reconcile(request)
+			if err != nil {
+				t.Errorf("Reconcile: %v", err)
+			}
+
+			err = client.Get(context.TODO(), types.NamespacedName{Name: test.newStorageClass.Name, Namespace: corev1.NamespaceAll}, test.newStorageClass)
+			if err != nil {
+				t.Errorf("Get: %v", err)
+			}
+			// Manually update the OwnerReferences to match the Operator added values
+			test.newStorageClass.OwnerReferences = test.expectedStorageClass.OwnerReferences
+
+			if !reflect.DeepEqual(test.newStorageClass, test.expectedStorageClass) {
+				t.Errorf("StorageClass doesn't match expected result: %v", test.newStorageClass)
+			}
+		})
+	}
+}
+
+func getFakeStorageClass(allowVolumeExpansion, isDefaultClass bool, provisioner string) *storagev1.StorageClass {
+	deletePolicy := corev1.PersistentVolumeReclaimDelete
+	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
+
+	sc := &storagev1.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StorageClass",
+			APIVersion: "storage.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gp2",
+			Annotations: map[string]string{
+				"storageclass.kubernetes.io/is-default-class": strconv.FormatBool(isDefaultClass),
+			},
+		},
+		AllowVolumeExpansion: &allowVolumeExpansion,
+		VolumeBindingMode:    &volumeBindingMode,
+		Parameters: map[string]string{
+			"encrypted": "true",
+			"type":      "gp2",
+		},
+		ReclaimPolicy: &deletePolicy,
+	}
+
+	if provisioner != "" {
+		sc.Provisioner = provisioner
+	}
+
+	return sc
 }


### PR DESCRIPTION
Updates the ClusterStorageOperator to check for changes made to the default StorageClass assets. If changes are found in either AllowVolumeExpansion or MountOptions, update the default StorageClass to use the new values.

This change also prevents users from adjusting these attributes from the ones used in the assets. We should likely document that restriction, and advise users to create a new storage class if changes are needed.