### PR TITLE
Bug 1816941: Move to openshift-cluster-storage-operators namespace

### DIFF
--- a/manifests/00-namespace.yaml
+++ b/manifests/00-namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: openshift-cluster-storage-operators
   annotations:
     openshift.io/node-selector: ""
-  name: openshift-cluster-storage-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/manifests/01-cluster-role-binding.yaml
+++ b/manifests/01-cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: cluster-storage-operator
-  namespace: openshift-cluster-storage-operator
+  namespace: openshift-cluster-storage-operators
 roleRef:
   kind: ClusterRole
   name: cluster-storage-operator

--- a/manifests/01-cluster-role.yaml
+++ b/manifests/01-cluster-role.yaml
@@ -38,3 +38,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups: [""]
+  resources:
+    - namespaces
+  resourceNames:
+    - openshift-cluster-storage-operator
+  verbs:
+    - delete

--- a/manifests/01-role-binding.yaml
+++ b/manifests/01-role-binding.yaml
@@ -2,7 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-storage-operator
-  namespace: openshift-cluster-storage-operator
+  namespace: openshift-cluster-storage-operators
 subjects:
 - kind: ServiceAccount
   name: cluster-storage-operator

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -2,7 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-storage-operator
-  namespace: openshift-cluster-storage-operator
+  namespace: openshift-cluster-storage-operators
 rules:
 - apiGroups:
   - storage.openshift.io

--- a/manifests/01-service-account.yaml
+++ b/manifests/01-service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cluster-storage-operator
-  namespace: openshift-cluster-storage-operator
+  namespace: openshift-cluster-storage-operators

--- a/manifests/02-deployment.yaml
+++ b/manifests/02-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-storage-operator
-  namespace: openshift-cluster-storage-operator
+  namespace: openshift-cluster-storage-operators
 spec:
   replicas: 1
   selector:

--- a/pkg/controller/clusterstorage/clusterstorage_controller.go
+++ b/pkg/controller/clusterstorage/clusterstorage_controller.go
@@ -365,7 +365,7 @@ func newStorageClassForCluster(infrastructure *configv1.Infrastructure) (*storag
 
 func getRelatedObjects(sc *storagev1.StorageClass) []configv1.ObjectReference {
 	relatedObjects := []configv1.ObjectReference{
-		{Resource: "namespaces", Name: "openshift-cluster-storage-operator"},
+		{Resource: "namespaces", Name: "openshift-cluster-storage-operators"},
 		{Group: "config.openshift.io", Resource: "infrastructures", Name: infrastructureName},
 	}
 	if sc != nil {


### PR DESCRIPTION
* Merge openshift-cluster-storage-operator and openshift-cluster-storage-operators namespaces.
* Delete old operator namespace (it is not deleted by CVO)
    * Add event handler for Namespaces and remove old namespace when it exists.
    * Make sure conditions are synced correctly:
         * Available = true when storage class exists.
         * Progressing = true when the operator has some work to do:
             * Either storage class does not exist.
             * Or the old namespace exists.
             * Or both.

WIP:
 - ~test must-gather~
 - test upgrade from 4.4