### PR TITLE
Bug 1835869: Included check for v1alpha VolumeSnapshot CRD

### DIFF
--- a/manifests/01-cluster-role.yaml
+++ b/manifests/01-cluster-role.yaml
@@ -38,3 +38,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"

--- a/pkg/controller/clusterstorage/clusterstorage_controller_test.go
+++ b/pkg/controller/clusterstorage/clusterstorage_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/cluster-storage-operator/pkg/apis"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -148,6 +149,9 @@ func TestReconcile(t *testing.T) {
 			}
 			if err := storagev1.AddToScheme(scheme); err != nil {
 				t.Errorf("storagev1.AddToScheme: %v", err)
+			}
+			if err := apiextv1beta1.AddToScheme(scheme); err != nil {
+				t.Errorf("apiextv1beta1.AddToScheme: %v", err)
 			}
 			client := fake.NewFakeClientWithScheme(scheme, clusterOperator, test.existingStorageClass, infrastructure)
 			reconciler := &ReconcileClusterStorage{client: client, scheme: scheme}

--- a/pkg/controller/validation/check_snapshot.go
+++ b/pkg/controller/validation/check_snapshot.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("check_snapshot")
+
+const (
+	snapshotCRDVersion = "v1alpha1"
+	snapshotCRDName    = "volumesnapshots.snapshot.storage.k8s.io"
+)
+
+// Returns an error if the v1alpha1 VolumeSnapshot CRD is installed in the cluster
+// and nil otherwise. This is used to prevent upgrading where clusters have manually
+// installed versions we don't support
+func CheckAlphaSnapshot(client client.Client) error {
+	snapshotCRD := &apiextv1beta1.CustomResourceDefinition{}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: snapshotCRDName, Namespace: corev1.NamespaceAll}, snapshotCRD)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// If we can't find the VolumeSnapshot CRD, then we're safe to proceed
+			return nil
+		}
+		log.Error(err, "Error attempting to obtain existing VolumeSnapshot CRD")
+		return err
+	}
+
+	for _, version := range snapshotCRD.Spec.Versions {
+		if version.Name == snapshotCRDVersion {
+			err = apierrors.NewConflict(schema.GroupResource{Resource: "VolumeSnapshot"},
+				"v1alpha1 VolumeSnapshot installed.", nil)
+			log.Error(err, "Unable to update cluster as VolumeSnapshot v1alpha1 is detected. Remove this version to allow the upgrade to proceed.")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/validation/check_snapshot_test.go
+++ b/pkg/controller/validation/check_snapshot_test.go
@@ -1,0 +1,79 @@
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCheckAlphaSnapshot(t *testing.T) {
+	tests := []struct {
+		name          string
+		snapshotCRD   *apiextv1beta1.CustomResourceDefinition
+		expectedError error
+	}{
+		{
+			name:          "no VolumeSnapshot installed, return nil",
+			snapshotCRD:   &apiextv1beta1.CustomResourceDefinition{},
+			expectedError: nil,
+		},
+		{
+			name:          "v1alpha1 VolumeSnapshot installed, return conflict error",
+			snapshotCRD:   getFakeSnapshotCRD("v1alpha1"),
+			expectedError: apierrors.NewConflict(schema.GroupResource{Resource: "VolumeSnapshot"}, "v1alpha1 VolumeSnapshot installed.", nil),
+		},
+		{
+			name:          "v1beta1 VolumeSnapshot installed, return nil",
+			snapshotCRD:   getFakeSnapshotCRD("v1beta1"),
+			expectedError: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := apiextv1beta1.AddToScheme(scheme); err != nil {
+				t.Errorf("apiextv1beta1.AddToScheme: %v", err)
+			}
+
+			client := fake.NewFakeClientWithScheme(scheme, test.snapshotCRD)
+			err := CheckAlphaSnapshot(client)
+
+			if test.expectedError != nil {
+				if !reflect.DeepEqual(err, test.expectedError) {
+					t.Errorf("Expected error doesn't match received error: %v \r\n %v", test.expectedError, err)
+				}
+			} else if err != nil {
+				t.Errorf("Test expects nil error, received: %v", err)
+			}
+		})
+	}
+}
+
+func getFakeSnapshotCRD(version string) *apiextv1beta1.CustomResourceDefinition {
+	crd := &apiextv1beta1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "volumesnapshots.snapshot.storage.k8s.io",
+		},
+		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
+			Version: version,
+			Versions: []apiextv1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    version,
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+	return crd
+}


### PR DESCRIPTION
This includes a check for the VolumeSnapshot CRD. If we detect v1alpha1 of the CRD, then we mark the Operator as Available, but Upgradeable=false.

Note that this needs to be included in 4.3; however, I think it would be useful to have some of these validations (since we're going to be checking for CSI Drivers) in current versions as well.