### PR TITLE
Bug 1835869: Updates validation to check for VolumeSnapshotClass and VolumeSnapshotContent

### DIFF
--- a/pkg/controller/validation/check_snapshot.go
+++ b/pkg/controller/validation/check_snapshot.go
@@ -2,11 +2,11 @@ package validation
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,32 +16,50 @@ import (
 var log = logf.Log.WithName("check_snapshot")
 
 const (
-	snapshotCRDVersion = "v1alpha1"
-	snapshotCRDName    = "volumesnapshots.snapshot.storage.k8s.io"
+	alphaVersion           = "v1alpha1"
+	snapshotCRDName        = "volumesnapshots.snapshot.storage.k8s.io"
+	snapshotClassCRDName   = "volumesnapshotclasses.snapshot.storage.k8s.io"
+	snapshotContentCRDName = "volumesnapshotcontents.snapshot.storage.k8s.io"
 )
 
-// Returns an error if the v1alpha1 VolumeSnapshot CRD is installed in the cluster
+type AlphaVersionError struct {
+	Msg string
+}
+
+func (e *AlphaVersionError) Error() string { return e.Msg }
+
+// Returns an error if the v1alpha1 CRD is installed in the cluster
 // and nil otherwise. This is used to prevent upgrading where clusters have manually
 // installed versions we don't support
-func CheckAlphaSnapshot(client client.Client) error {
-	snapshotCRD := &apiextv1beta1.CustomResourceDefinition{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: snapshotCRDName, Namespace: corev1.NamespaceAll}, snapshotCRD)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// If we can't find the VolumeSnapshot CRD, then we're safe to proceed
-			return nil
-		}
-		log.Error(err, "Error attempting to obtain existing VolumeSnapshot CRD")
-		return err
-	}
 
-	for _, version := range snapshotCRD.Spec.Versions {
-		if version.Name == snapshotCRDVersion {
-			err = apierrors.NewConflict(schema.GroupResource{Resource: "VolumeSnapshot"},
-				"v1alpha1 VolumeSnapshot installed.", nil)
-			log.Error(err, "Unable to update cluster as VolumeSnapshot v1alpha1 is detected. Remove this version to allow the upgrade to proceed.")
-			return err
+func CheckAlphaSnapshot(client client.Client) error {
+	crdMap := map[string]string{"VolumeSnapshot": snapshotCRDName,
+		"VolumeSnapshotClass":   snapshotClassCRDName,
+		"VolumeSnapshotContent": snapshotContentCRDName}
+	foundCRD := []string{}
+	crd := &apiextv1beta1.CustomResourceDefinition{}
+	for k, v := range crdMap {
+		err := client.Get(context.TODO(), types.NamespacedName{Name: v, Namespace: corev1.NamespaceAll}, crd)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				errMsg := "Error attempting to obtain existing " + k + " CRD."
+				log.Error(err, errMsg)
+				return err
+			}
+			log.V(5).Info("CRD for " + k + " not found.")
+			continue
 		}
+
+		for _, version := range crd.Spec.Versions {
+			if version.Name == alphaVersion {
+				foundCRD = append(foundCRD, v)
+				log.Error(err, "v1alpha1 "+k+" installed")
+			}
+		}
+	}
+	if len(foundCRD) > 0 {
+		errString := "Unable to update cluster as v1alpha1 version of " + strings.Join(foundCRD, ", ") + "is detected. Remove these CRDs to allow the upgrade to proceed."
+		return &AlphaVersionError{errString}
 	}
 	return nil
 }


### PR DESCRIPTION
Continues the work in BZ1835869 to check for VolumeSnapshotClass and VolumeSnapshotContent. This puts the CRDs into a map and runs through them, building up the final error message along the way.