### PR TITLE
Fix installation on usupported platforms like oVirt

### DIFF
--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -98,10 +98,17 @@ func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) erro
 				Reason:  "UnsupportedPlatform",
 				Message: syncErr.Error(),
 			}
+			// Set Available=true, Progressing=false - everything is OK and
+			// there is nothing to do. ClusterOperatorStatusController needs
+			// at least one Available/Pogressing condition set to mark the
+			// overall ClusterOperator as Available + notPogressing.
+			availableCnd.Message = "No default StorageClass for this platform"
+			availableCnd.Status = operatorapi.ConditionTrue
+
 			_, _, updateErr := v1helpers.UpdateStatus(c.operatorClient,
 				v1helpers.UpdateConditionFn(disabledCnd),
-				removeConditionFn(conditionsPrefix+operatorapi.OperatorStatusTypeAvailable),
-				removeConditionFn(conditionsPrefix+operatorapi.OperatorStatusTypeProgressing),
+				v1helpers.UpdateConditionFn(availableCnd),
+				v1helpers.UpdateConditionFn(progressingCnd),
 			)
 			return updateErr
 		}

--- a/pkg/operator/defaultstorageclass/controller_test.go
+++ b/pkg/operator/defaultstorageclass/controller_test.go
@@ -213,7 +213,8 @@ func TestSync(t *testing.T) {
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix + "Disabled"),
+					withTrueConditions(conditionsPrefix+"Disabled", conditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 			},
 			expectErr: false,


### PR DESCRIPTION
The operator should mark itself as `Available` when on a platform that does not have a default StorageClass (yet).

library-go status syncer expects at least Available condition in `storage` CR to mark the OperatorStatus as `Available`.

cc @openshift/storage 