### PR TITLE
Add oVirt and manila to CSO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL :=/bin/bash
-
 all: build
 .PHONY: all
 
@@ -27,7 +25,7 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
-$(call build-image,cluster-storage-operator,$(IMAGE_REGISTRY)/ocp/4.5:cluster-storage-operator,./Dockerfile.rhel7,.)
+$(call build-image,cluster-storage-operator,$(IMAGE_REGISTRY)/ocp/4.6:cluster-storage-operator,./Dockerfile.rhel7,.)
 
 # generate bindata targets
 # $0 - macro name

--- a/assets/csidriveroperators/manila/01_namespace.yaml
+++ b/assets/csidriveroperators/manila/01_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/manila/02_sa.yaml
+++ b/assets/csidriveroperators/manila/02_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/manila/03_role.yaml
+++ b/assets/csidriveroperators/manila/03_role.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manila-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create

--- a/assets/csidriveroperators/manila/04_rolebinding.yaml
+++ b/assets/csidriveroperators/manila/04_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manila-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manila-csi-driver-operator-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -1,0 +1,239 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manila-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - manila-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - csi.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - 'clustercsidrivers'
+  - 'clustercsidrivers/status'
+  verbs:
+  - '*'

--- a/assets/csidriveroperators/manila/06_clusterrolebinding.yaml
+++ b/assets/csidriveroperators/manila/06_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manila-csi-driver-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manila-csi-driver-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: manila-csi-driver-operator
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: manila-csi-driver-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=${LOG_LEVEL}
+        env:
+        - name: DRIVER_IMAGE
+          value: ${DRIVER_IMAGE}
+        - name: NFS_DRIVER_IMAGE
+          value: ${NFS_DRIVER_IMAGE}
+        - name: PROVISIONER_IMAGE
+          value: ${PROVISIONER_IMAGE}
+        - name: ATTACHER_IMAGE
+          value: ${ATTACHER_IMAGE}
+        - name: RESIZER_IMAGE
+          value: ${RESIZER_IMAGE}
+        - name: SNAPSHOTTER_IMAGE
+          value: ${SNAPSHOTTER_IMAGE}
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        - name: LIVENESS_PROBE_IMAGE
+          value: ${LIVENESS_PROBE_IMAGE}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: manila-csi-driver-operator
+        volumeMounts:
+        - name: cacert
+          mountPath: /etc/openstack-ca/
+        - name: cloud-credentials
+          # Create /etc/openstack/clouds.yaml
+          mountPath: /etc/openstack/
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+      priorityClassName: system-cluster-critical
+      serviceAccountName: manila-csi-driver-operator
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - name: cacert
+        # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
+        # Let the pod start when the ConfigMap does not exist or the certificate
+        # is not preset there. The certificate file will be created once the
+        # ConfigMap is created / the cerificate is added to it.
+        configMap:
+          name: cloud-provider-config
+          items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+          optional: true
+      - name: cloud-credentials
+        secret:
+          secretName: manila-cloud-credentials
+          optional: false

--- a/assets/csidriveroperators/manila/08_cr.yaml
+++ b/assets/csidriveroperators/manila/08_cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: manila.csi.openstack.org
+spec:
+  managementState: Managed
+  logLevel: Normal
+  operatorLogLevel: Normal
+  driverConfig:
+    driverName: manila.csi.openstack.org

--- a/assets/csidriveroperators/manila/09_credentials.yaml
+++ b/assets/csidriveroperators/manila/09_credentials.yaml
@@ -1,0 +1,12 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-manila-csi-driver
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: manila-cloud-credentials
+    namespace: openshift-cluster-csi-drivers
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OpenStackProviderSpec

--- a/assets/csidriveroperators/ovirt/01_namespace.yaml
+++ b/assets/csidriveroperators/ovirt/01_namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/ovirt/02_sa.yaml
+++ b/assets/csidriveroperators/ovirt/02_sa.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/ovirt/03_role.yaml
+++ b/assets/csidriveroperators/ovirt/03_role.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovirt-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create

--- a/assets/csidriveroperators/ovirt/04_rolebinding.yaml
+++ b/assets/csidriveroperators/ovirt/04_rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovirt-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovirt-csi-driver-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: ovirt-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -1,0 +1,243 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovirt-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - ovirt-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - csi.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers
+  - clustercsidrivers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update

--- a/assets/csidriveroperators/ovirt/06_clusterrolebinding.yaml
+++ b/assets/csidriveroperators/ovirt/06_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovirt-csi-driver-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ovirt-csi-driver-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/ovirt/07_deployment.yaml
+++ b/assets/csidriveroperators/ovirt/07_deployment.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ovirt-csi-driver-operator
+  template:
+    metadata:
+      labels:
+        name: ovirt-csi-driver-operator
+    spec:
+      serviceAccountName: ovirt-csi-driver-operator
+      priorityClassName: system-cluster-critical
+      initContainers:
+        - name: prepare-ovirt-config
+          env:
+            - name: OVIRT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_url
+            - name: OVIRT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_username
+            - name: OVIRT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_password
+            - name: OVIRT_CAFILE
+              value: /tmp/config/ovirt-engine-ca.pem
+            - name: OVIRT_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_insecure
+            - name: OVIRT_CA_BUNDLE
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_ca_bundle
+          image: ${OPERATOR_IMAGE}
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          command:
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/sh
+              cat << EOF > /tmp/config/ovirt-config.yaml
+              ovirt_url: $OVIRT_URL
+              ovirt_username: $OVIRT_USERNAME
+              ovirt_password: $OVIRT_PASSWORD
+              # set a valid path only if ca bundle has content
+              ovirt_cafile: ${OVIRT_CA_BUNDLE:+$OVIRT_CAFILE}
+              ovirt_insecure: $OVIRT_INSECURE
+              EOF
+              if [[ -n "$OVIRT_CA_BUNDLE" ]]; then echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE ; fi
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+
+      containers:
+        - name: ovirt-csi-driver-operator
+          image: ${OPERATOR_IMAGE}
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+          args:
+            - start
+            - "--node=$(KUBE_NODE_NAME)"
+            - -v=${LOG_LEVEL}
+          env:
+            - name: OPERATOR_NAME
+              value: ovirt-csi-driver-operator
+            - name: DRIVER_IMAGE
+              value: ${DRIVER_IMAGE}
+            - name: PROVISIONER_IMAGE
+              value: ${PROVISIONER_IMAGE}
+            - name: ATTACHER_IMAGE
+              value: ${ATTACHER_IMAGE}
+            - name: RESIZER_IMAGE
+              value: ${RESIZER_IMAGE}
+            - name: SNAPSHOTTER_IMAGE
+              value: ${SNAPSHOTTER_IMAGE}
+            - name: NODE_DRIVER_REGISTRAR_IMAGE
+              value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+            - name: LIVENESS_PROBE_IMAGE
+              value: ${LIVENESS_PROBE_IMAGE}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+
+            - name: OVIRT_CONFIG
+              value: /tmp/config/ovirt-config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+      volumes:
+        - name: config
+          emptyDir: {}

--- a/assets/csidriveroperators/ovirt/08_cr.yaml
+++ b/assets/csidriveroperators/ovirt/08_cr.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: csi.ovirt.org
+spec:
+  driverConfig:
+    driverName: csi.ovirt.org
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal

--- a/assets/csidriveroperators/ovirt/09_credential_request.yaml
+++ b/assets/csidriveroperators/ovirt/09_credential_request.yaml
@@ -1,0 +1,12 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OvirtProviderSpec
+  secretRef:
+    name: ovirt-credentials
+    namespace: openshift-cluster-csi-drivers

--- a/manifests/04_deployment.yaml
+++ b/manifests/04_deployment.yaml
@@ -53,6 +53,12 @@ spec:
             value: quay.io/openshift/origin-ovirt-csi-driver-operator:latest
           - name: OVIRT_DRIVER_IMAGE
             value: quay.io/openshift/origin-ovirt-csi-driver:latest
+          - name: MANILA_DRIVER_OPERATOR_IMAGE
+            value: quay.io/openshift/origin-csi-driver-manila-operator:latest
+          - name: MANILA_DRIVER_IMAGE
+            value: quay.io/openshift/origin-csi-driver-manila:latest
+          - name: MANILA_NSF_DRIVER_IMAGE
+            value: quay.io/openshift/origin-csi-driver-nfs:latest
           - name: PROVISIONER_IMAGE
             value: quay.io/openshift/origin-csi-external-provisioner:latest
           - name: ATTACHER_IMAGE

--- a/manifests/04_deployment.yaml
+++ b/manifests/04_deployment.yaml
@@ -49,6 +49,10 @@ spec:
             value: quay.io/openshift/origin-aws-ebs-csi-driver-operator:latest
           - name: AWS_EBS_DRIVER_IMAGE
             value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+          - name: OVIRT_DRIVER_OPERATOR_IMAGE
+            value: quay.io/openshift/origin-ovirt-csi-driver-operator:latest
+          - name: OVIRT_DRIVER_IMAGE
+            value: quay.io/openshift/origin-ovirt-csi-driver:latest
           - name: PROVISIONER_IMAGE
             value: quay.io/openshift/origin-csi-external-provisioner:latest
           - name: ATTACHER_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -22,6 +22,18 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ovirt-csi-driver:latest
+  - name: csi-driver-manila-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-driver-manila-operator:latest
+  - name: csi-driver-manila
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-driver-manila:latest
+  - name: csi-driver-nfs
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-driver-nfs:latest
   - name: csi-external-provisioner
     from:
       kind: DockerImage

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,6 +14,14 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+  - name: ovirt-csi-driver-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ovirt-csi-driver-operator:latest
+  - name: ovirt-csi-driver
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ovirt-csi-driver:latest
   - name: csi-external-provisioner
     from:
       kind: DockerImage

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -8,6 +8,15 @@
 // assets/csidriveroperators/aws-ebs/06_clusterrolebinding.yaml
 // assets/csidriveroperators/aws-ebs/07_deployment.yaml
 // assets/csidriveroperators/aws-ebs/08_cr.yaml
+// assets/csidriveroperators/ovirt/01_namespace.yaml
+// assets/csidriveroperators/ovirt/02_sa.yaml
+// assets/csidriveroperators/ovirt/03_role.yaml
+// assets/csidriveroperators/ovirt/04_rolebinding.yaml
+// assets/csidriveroperators/ovirt/05_clusterrole.yaml
+// assets/csidriveroperators/ovirt/06_clusterrolebinding.yaml
+// assets/csidriveroperators/ovirt/07_deployment.yaml
+// assets/csidriveroperators/ovirt/08_cr.yaml
+// assets/csidriveroperators/ovirt/09_credential_request.yaml
 // assets/storageclasses/aws.yaml
 // assets/storageclasses/azure.yaml
 // assets/storageclasses/gcp.yaml
@@ -581,6 +590,624 @@ func csidriveroperatorsAwsEbs08_crYaml() (*asset, error) {
 	return a, nil
 }
 
+var _csidriveroperatorsOvirt01_namespaceYaml = []byte(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsOvirt01_namespaceYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt01_namespaceYaml, nil
+}
+
+func csidriveroperatorsOvirt01_namespaceYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt01_namespaceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/01_namespace.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt02_saYaml = []byte(`---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsOvirt02_saYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt02_saYaml, nil
+}
+
+func csidriveroperatorsOvirt02_saYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt02_saYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/02_sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt03_roleYaml = []byte(`---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ovirt-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+`)
+
+func csidriveroperatorsOvirt03_roleYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt03_roleYaml, nil
+}
+
+func csidriveroperatorsOvirt03_roleYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt03_roleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/03_role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt04_rolebindingYaml = []byte(`---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ovirt-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ovirt-csi-driver-operator-role
+subjects:
+  - kind: ServiceAccount
+    name: ovirt-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsOvirt04_rolebindingYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt04_rolebindingYaml, nil
+}
+
+func csidriveroperatorsOvirt04_rolebindingYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt04_rolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/04_rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt05_clusterroleYaml = []byte(`---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovirt-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - ovirt-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - csi.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers
+  - clustercsidrivers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+`)
+
+func csidriveroperatorsOvirt05_clusterroleYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt05_clusterroleYaml, nil
+}
+
+func csidriveroperatorsOvirt05_clusterroleYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt05_clusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/05_clusterrole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt06_clusterrolebindingYaml = []byte(`---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovirt-csi-driver-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ovirt-csi-driver-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsOvirt06_clusterrolebindingYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt06_clusterrolebindingYaml, nil
+}
+
+func csidriveroperatorsOvirt06_clusterrolebindingYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt06_clusterrolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/06_clusterrolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt07_deploymentYaml = []byte(`---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: ovirt-csi-driver-operator
+  template:
+    metadata:
+      labels:
+        name: ovirt-csi-driver-operator
+    spec:
+      serviceAccountName: ovirt-csi-driver-operator
+      priorityClassName: system-cluster-critical
+      initContainers:
+        - name: prepare-ovirt-config
+          env:
+            - name: OVIRT_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_url
+            - name: OVIRT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_username
+            - name: OVIRT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_password
+            - name: OVIRT_CAFILE
+              value: /tmp/config/ovirt-engine-ca.pem
+            - name: OVIRT_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_insecure
+            - name: OVIRT_CA_BUNDLE
+              valueFrom:
+                secretKeyRef:
+                  name: ovirt-credentials
+                  key: ovirt_ca_bundle
+          image: ${OPERATOR_IMAGE}
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          command:
+            - /bin/sh
+            - -c
+            - |
+              #!/bin/sh
+              cat << EOF > /tmp/config/ovirt-config.yaml
+              ovirt_url: $OVIRT_URL
+              ovirt_username: $OVIRT_USERNAME
+              ovirt_password: $OVIRT_PASSWORD
+              # set a valid path only if ca bundle has content
+              ovirt_cafile: ${OVIRT_CA_BUNDLE:+$OVIRT_CAFILE}
+              ovirt_insecure: $OVIRT_INSECURE
+              EOF
+              if [[ -n "$OVIRT_CA_BUNDLE" ]]; then echo "$OVIRT_CA_BUNDLE" > $OVIRT_CAFILE ; fi
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+
+      containers:
+        - name: ovirt-csi-driver-operator
+          image: ${OPERATOR_IMAGE}
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+          args:
+            - start
+            - "--node=$(KUBE_NODE_NAME)"
+            - -v=${LOG_LEVEL}
+          env:
+            - name: OPERATOR_NAME
+              value: ovirt-csi-driver-operator
+            - name: DRIVER_IMAGE
+              value: ${DRIVER_IMAGE}
+            - name: PROVISIONER_IMAGE
+              value: ${PROVISIONER_IMAGE}
+            - name: ATTACHER_IMAGE
+              value: ${ATTACHER_IMAGE}
+            - name: RESIZER_IMAGE
+              value: ${RESIZER_IMAGE}
+            - name: SNAPSHOTTER_IMAGE
+              value: ${SNAPSHOTTER_IMAGE}
+            - name: NODE_DRIVER_REGISTRAR_IMAGE
+              value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+            - name: LIVENESS_PROBE_IMAGE
+              value: ${LIVENESS_PROBE_IMAGE}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+
+            - name: OVIRT_CONFIG
+              value: /tmp/config/ovirt-config.yaml
+          volumeMounts:
+            - name: config
+              mountPath: /tmp/config
+      volumes:
+        - name: config
+          emptyDir: {}
+`)
+
+func csidriveroperatorsOvirt07_deploymentYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt07_deploymentYaml, nil
+}
+
+func csidriveroperatorsOvirt07_deploymentYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt07_deploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/07_deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt08_crYaml = []byte(`---
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: csi.ovirt.org
+spec:
+  driverConfig:
+    driverName: csi.ovirt.org
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal
+`)
+
+func csidriveroperatorsOvirt08_crYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt08_crYaml, nil
+}
+
+func csidriveroperatorsOvirt08_crYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt08_crYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/08_cr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsOvirt09_credential_requestYaml = []byte(`apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OvirtProviderSpec
+  secretRef:
+    name: ovirt-credentials
+    namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsOvirt09_credential_requestYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsOvirt09_credential_requestYaml, nil
+}
+
+func csidriveroperatorsOvirt09_credential_requestYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsOvirt09_credential_requestYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/ovirt/09_credential_request.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _storageclassesAwsYaml = []byte(`apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -784,6 +1411,15 @@ var _bindata = map[string]func() (*asset, error){
 	"csidriveroperators/aws-ebs/06_clusterrolebinding.yaml": csidriveroperatorsAwsEbs06_clusterrolebindingYaml,
 	"csidriveroperators/aws-ebs/07_deployment.yaml":         csidriveroperatorsAwsEbs07_deploymentYaml,
 	"csidriveroperators/aws-ebs/08_cr.yaml":                 csidriveroperatorsAwsEbs08_crYaml,
+	"csidriveroperators/ovirt/01_namespace.yaml":            csidriveroperatorsOvirt01_namespaceYaml,
+	"csidriveroperators/ovirt/02_sa.yaml":                   csidriveroperatorsOvirt02_saYaml,
+	"csidriveroperators/ovirt/03_role.yaml":                 csidriveroperatorsOvirt03_roleYaml,
+	"csidriveroperators/ovirt/04_rolebinding.yaml":          csidriveroperatorsOvirt04_rolebindingYaml,
+	"csidriveroperators/ovirt/05_clusterrole.yaml":          csidriveroperatorsOvirt05_clusterroleYaml,
+	"csidriveroperators/ovirt/06_clusterrolebinding.yaml":   csidriveroperatorsOvirt06_clusterrolebindingYaml,
+	"csidriveroperators/ovirt/07_deployment.yaml":           csidriveroperatorsOvirt07_deploymentYaml,
+	"csidriveroperators/ovirt/08_cr.yaml":                   csidriveroperatorsOvirt08_crYaml,
+	"csidriveroperators/ovirt/09_credential_request.yaml":   csidriveroperatorsOvirt09_credential_requestYaml,
 	"storageclasses/aws.yaml":                               storageclassesAwsYaml,
 	"storageclasses/azure.yaml":                             storageclassesAzureYaml,
 	"storageclasses/gcp.yaml":                               storageclassesGcpYaml,
@@ -842,6 +1478,17 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"06_clusterrolebinding.yaml": {csidriveroperatorsAwsEbs06_clusterrolebindingYaml, map[string]*bintree{}},
 			"07_deployment.yaml":         {csidriveroperatorsAwsEbs07_deploymentYaml, map[string]*bintree{}},
 			"08_cr.yaml":                 {csidriveroperatorsAwsEbs08_crYaml, map[string]*bintree{}},
+		}},
+		"ovirt": {nil, map[string]*bintree{
+			"01_namespace.yaml":          {csidriveroperatorsOvirt01_namespaceYaml, map[string]*bintree{}},
+			"02_sa.yaml":                 {csidriveroperatorsOvirt02_saYaml, map[string]*bintree{}},
+			"03_role.yaml":               {csidriveroperatorsOvirt03_roleYaml, map[string]*bintree{}},
+			"04_rolebinding.yaml":        {csidriveroperatorsOvirt04_rolebindingYaml, map[string]*bintree{}},
+			"05_clusterrole.yaml":        {csidriveroperatorsOvirt05_clusterroleYaml, map[string]*bintree{}},
+			"06_clusterrolebinding.yaml": {csidriveroperatorsOvirt06_clusterrolebindingYaml, map[string]*bintree{}},
+			"07_deployment.yaml":         {csidriveroperatorsOvirt07_deploymentYaml, map[string]*bintree{}},
+			"08_cr.yaml":                 {csidriveroperatorsOvirt08_crYaml, map[string]*bintree{}},
+			"09_credential_request.yaml": {csidriveroperatorsOvirt09_credential_requestYaml, map[string]*bintree{}},
 		}},
 	}},
 	"storageclasses": {nil, map[string]*bintree{

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -8,6 +8,15 @@
 // assets/csidriveroperators/aws-ebs/06_clusterrolebinding.yaml
 // assets/csidriveroperators/aws-ebs/07_deployment.yaml
 // assets/csidriveroperators/aws-ebs/08_cr.yaml
+// assets/csidriveroperators/manila/01_namespace.yaml
+// assets/csidriveroperators/manila/02_sa.yaml
+// assets/csidriveroperators/manila/03_role.yaml
+// assets/csidriveroperators/manila/04_rolebinding.yaml
+// assets/csidriveroperators/manila/05_clusterrole.yaml
+// assets/csidriveroperators/manila/06_clusterrolebinding.yaml
+// assets/csidriveroperators/manila/07_deployment.yaml
+// assets/csidriveroperators/manila/08_cr.yaml
+// assets/csidriveroperators/manila/09_credentials.yaml
 // assets/csidriveroperators/ovirt/01_namespace.yaml
 // assets/csidriveroperators/ovirt/02_sa.yaml
 // assets/csidriveroperators/ovirt/03_role.yaml
@@ -586,6 +595,569 @@ func csidriveroperatorsAwsEbs08_crYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "csidriveroperators/aws-ebs/08_cr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila01_namespaceYaml = []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsManila01_namespaceYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila01_namespaceYaml, nil
+}
+
+func csidriveroperatorsManila01_namespaceYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila01_namespaceYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/01_namespace.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila02_saYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsManila02_saYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila02_saYaml, nil
+}
+
+func csidriveroperatorsManila02_saYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila02_saYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/02_sa.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila03_roleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: manila-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+`)
+
+func csidriveroperatorsManila03_roleYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila03_roleYaml, nil
+}
+
+func csidriveroperatorsManila03_roleYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila03_roleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/03_role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila04_rolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manila-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: manila-csi-driver-operator-role
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsManila04_rolebindingYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila04_rolebindingYaml, nil
+}
+
+func csidriveroperatorsManila04_rolebindingYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila04_rolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/04_rolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila05_clusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manila-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - manila-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - csi.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - 'clustercsidrivers'
+  - 'clustercsidrivers/status'
+  verbs:
+  - '*'
+`)
+
+func csidriveroperatorsManila05_clusterroleYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila05_clusterroleYaml, nil
+}
+
+func csidriveroperatorsManila05_clusterroleYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila05_clusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/05_clusterrole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila06_clusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manila-csi-driver-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manila-csi-driver-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+`)
+
+func csidriveroperatorsManila06_clusterrolebindingYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila06_clusterrolebindingYaml, nil
+}
+
+func csidriveroperatorsManila06_clusterrolebindingYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila06_clusterrolebindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/06_clusterrolebinding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila07_deploymentYaml = []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manila-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: manila-csi-driver-operator
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        name: manila-csi-driver-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=${LOG_LEVEL}
+        env:
+        - name: DRIVER_IMAGE
+          value: ${DRIVER_IMAGE}
+        - name: NFS_DRIVER_IMAGE
+          value: ${NFS_DRIVER_IMAGE}
+        - name: PROVISIONER_IMAGE
+          value: ${PROVISIONER_IMAGE}
+        - name: ATTACHER_IMAGE
+          value: ${ATTACHER_IMAGE}
+        - name: RESIZER_IMAGE
+          value: ${RESIZER_IMAGE}
+        - name: SNAPSHOTTER_IMAGE
+          value: ${SNAPSHOTTER_IMAGE}
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        - name: LIVENESS_PROBE_IMAGE
+          value: ${LIVENESS_PROBE_IMAGE}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: manila-csi-driver-operator
+        volumeMounts:
+        - name: cacert
+          mountPath: /etc/openstack-ca/
+        - name: cloud-credentials
+          # Create /etc/openstack/clouds.yaml
+          mountPath: /etc/openstack/
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+      priorityClassName: system-cluster-critical
+      serviceAccountName: manila-csi-driver-operator
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - name: cacert
+        # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
+        # Let the pod start when the ConfigMap does not exist or the certificate
+        # is not preset there. The certificate file will be created once the
+        # ConfigMap is created / the cerificate is added to it.
+        configMap:
+          name: cloud-provider-config
+          items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+          optional: true
+      - name: cloud-credentials
+        secret:
+          secretName: manila-cloud-credentials
+          optional: false
+`)
+
+func csidriveroperatorsManila07_deploymentYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila07_deploymentYaml, nil
+}
+
+func csidriveroperatorsManila07_deploymentYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila07_deploymentYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/07_deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila08_crYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: manila.csi.openstack.org
+spec:
+  managementState: Managed
+  logLevel: Normal
+  operatorLogLevel: Normal
+  driverConfig:
+    driverName: manila.csi.openstack.org
+`)
+
+func csidriveroperatorsManila08_crYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila08_crYaml, nil
+}
+
+func csidriveroperatorsManila08_crYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila08_crYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/08_cr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _csidriveroperatorsManila09_credentialsYaml = []byte(`apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-manila-csi-driver
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: manila-cloud-credentials
+    namespace: openshift-cluster-csi-drivers
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: OpenStackProviderSpec
+`)
+
+func csidriveroperatorsManila09_credentialsYamlBytes() ([]byte, error) {
+	return _csidriveroperatorsManila09_credentialsYaml, nil
+}
+
+func csidriveroperatorsManila09_credentialsYaml() (*asset, error) {
+	bytes, err := csidriveroperatorsManila09_credentialsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "csidriveroperators/manila/09_credentials.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1411,6 +1983,15 @@ var _bindata = map[string]func() (*asset, error){
 	"csidriveroperators/aws-ebs/06_clusterrolebinding.yaml": csidriveroperatorsAwsEbs06_clusterrolebindingYaml,
 	"csidriveroperators/aws-ebs/07_deployment.yaml":         csidriveroperatorsAwsEbs07_deploymentYaml,
 	"csidriveroperators/aws-ebs/08_cr.yaml":                 csidriveroperatorsAwsEbs08_crYaml,
+	"csidriveroperators/manila/01_namespace.yaml":           csidriveroperatorsManila01_namespaceYaml,
+	"csidriveroperators/manila/02_sa.yaml":                  csidriveroperatorsManila02_saYaml,
+	"csidriveroperators/manila/03_role.yaml":                csidriveroperatorsManila03_roleYaml,
+	"csidriveroperators/manila/04_rolebinding.yaml":         csidriveroperatorsManila04_rolebindingYaml,
+	"csidriveroperators/manila/05_clusterrole.yaml":         csidriveroperatorsManila05_clusterroleYaml,
+	"csidriveroperators/manila/06_clusterrolebinding.yaml":  csidriveroperatorsManila06_clusterrolebindingYaml,
+	"csidriveroperators/manila/07_deployment.yaml":          csidriveroperatorsManila07_deploymentYaml,
+	"csidriveroperators/manila/08_cr.yaml":                  csidriveroperatorsManila08_crYaml,
+	"csidriveroperators/manila/09_credentials.yaml":         csidriveroperatorsManila09_credentialsYaml,
 	"csidriveroperators/ovirt/01_namespace.yaml":            csidriveroperatorsOvirt01_namespaceYaml,
 	"csidriveroperators/ovirt/02_sa.yaml":                   csidriveroperatorsOvirt02_saYaml,
 	"csidriveroperators/ovirt/03_role.yaml":                 csidriveroperatorsOvirt03_roleYaml,
@@ -1478,6 +2059,17 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"06_clusterrolebinding.yaml": {csidriveroperatorsAwsEbs06_clusterrolebindingYaml, map[string]*bintree{}},
 			"07_deployment.yaml":         {csidriveroperatorsAwsEbs07_deploymentYaml, map[string]*bintree{}},
 			"08_cr.yaml":                 {csidriveroperatorsAwsEbs08_crYaml, map[string]*bintree{}},
+		}},
+		"manila": {nil, map[string]*bintree{
+			"01_namespace.yaml":          {csidriveroperatorsManila01_namespaceYaml, map[string]*bintree{}},
+			"02_sa.yaml":                 {csidriveroperatorsManila02_saYaml, map[string]*bintree{}},
+			"03_role.yaml":               {csidriveroperatorsManila03_roleYaml, map[string]*bintree{}},
+			"04_rolebinding.yaml":        {csidriveroperatorsManila04_rolebindingYaml, map[string]*bintree{}},
+			"05_clusterrole.yaml":        {csidriveroperatorsManila05_clusterroleYaml, map[string]*bintree{}},
+			"06_clusterrolebinding.yaml": {csidriveroperatorsManila06_clusterrolebindingYaml, map[string]*bintree{}},
+			"07_deployment.yaml":         {csidriveroperatorsManila07_deploymentYaml, map[string]*bintree{}},
+			"08_cr.yaml":                 {csidriveroperatorsManila08_crYaml, map[string]*bintree{}},
+			"09_credentials.yaml":        {csidriveroperatorsManila09_credentialsYaml, map[string]*bintree{}},
 		}},
 		"ovirt": {nil, map[string]*bintree{
 			"01_namespace.yaml":          {csidriveroperatorsOvirt01_namespaceYaml, map[string]*bintree{}},

--- a/pkg/operator/csidriveroperator/csioperatorclient/manila.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/manila.go
@@ -1,0 +1,85 @@
+package csioperatorclient
+
+import (
+	"os"
+	"strings"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
+	"github.com/openshift/cluster-storage-operator/pkg/generated"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+)
+
+const (
+	CloudConfigNamespace = "openshift-config"
+	CloudConfigName      = "cloud-provider-config"
+
+	envManilaDriverOperatorImage = "MANILA_DRIVER_OPERATOR_IMAGE"
+	envManilaDriverImage         = "MANILA_DRIVER_IMAGE"
+	envNFSDriverImage            = "MANILA_NFS_DRIVER_IMAGE"
+)
+
+func GetManilaOperatorConfig(clients *csoclients.Clients, recorder events.Recorder) CSIOperatorConfig {
+	pairs := []string{
+		"${OPERATOR_IMAGE}", os.Getenv(envManilaDriverOperatorImage),
+		"${DRIVER_IMAGE}", os.Getenv(envManilaDriverImage),
+		"${NFS_DRIVER_IMAGE}", os.Getenv(envNFSDriverImage),
+	}
+
+	return CSIOperatorConfig{
+		CSIDriverName:   "manila.csi.openstack.org",
+		ConditionPrefix: "Manila",
+		Platform:        v1.OpenStackPlatformType,
+		StaticAssets: []string{
+			"csidriveroperators/manila/01_namespace.yaml",
+			"csidriveroperators/manila/02_sa.yaml",
+			"csidriveroperators/manila/03_role.yaml",
+			"csidriveroperators/manila/04_rolebinding.yaml",
+			"csidriveroperators/manila/05_clusterrole.yaml",
+			"csidriveroperators/manila/06_clusterrolebinding.yaml",
+		},
+		CRAsset:         "csidriveroperators/manila/08_cr.yaml",
+		DeploymentAsset: "csidriveroperators/manila/07_deployment.yaml",
+		ImageReplacer:   strings.NewReplacer(pairs...),
+		ExtraControllers: []factory.Controller{
+			newSecretSyncer(clients, recorder),
+			newManilaCredentialsRequest(clients, recorder),
+		},
+		Optional: true,
+	}
+}
+
+func newSecretSyncer(clients *csoclients.Clients, recorder events.Recorder) factory.Controller {
+	// sync config map with OpenStack CA certificate to the operator namespace,
+	// so the operator can get it as a ConfigMap volume.
+	srcConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: CloudConfigNamespace,
+		Name:      CloudConfigName,
+	}
+	dstConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: csoclients.CSIOperatorNamespace,
+		Name:      CloudConfigName,
+	}
+	certController := resourcesynccontroller.NewResourceSyncController(
+		clients.OperatorClient,
+		clients.KubeInformers,
+		clients.KubeClient.CoreV1(),
+		clients.KubeClient.CoreV1(),
+		recorder)
+	certController.SyncConfigMap(dstConfigMap, srcConfigMap)
+	return certController
+}
+
+func newManilaCredentialsRequest(clients *csoclients.Clients, recorder events.Recorder) factory.Controller {
+	crController := credentialsrequestcontroller.NewCredentialsRequestController(
+		"Manila",
+		csoclients.CSIOperatorNamespace,
+		generated.MustAsset("csidriveroperators/manila/09_credentials.yaml"),
+		clients.DynamicClient,
+		clients.OperatorClient,
+		recorder)
+	return crController
+}

--- a/pkg/operator/csidriveroperator/csioperatorclient/ovirt.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/ovirt.go
@@ -1,0 +1,58 @@
+package csioperatorclient
+
+import (
+	"os"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
+	"github.com/openshift/cluster-storage-operator/pkg/generated"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	OVirtDriverName             = "csi.ovirt.org"
+	envOVirtDriverOperatorImage = "OVIRT_DRIVER_OPERATOR_IMAGE"
+	envOVirtDriverImage         = "OVIRT_DRIVER_IMAGE"
+)
+
+func GetOVirtCSIOperatorConfig(clients *csoclients.Clients, recorder events.Recorder) CSIOperatorConfig {
+	pairs := []string{
+		"${OPERATOR_IMAGE}", os.Getenv(envOVirtDriverOperatorImage),
+		"${DRIVER_IMAGE}", os.Getenv(envOVirtDriverImage),
+	}
+
+	return CSIOperatorConfig{
+		CSIDriverName:   OVirtDriverName,
+		ConditionPrefix: "OVirt",
+		Platform:        configv1.OvirtPlatformType,
+		StaticAssets: []string{
+			"csidriveroperators/ovirt/01_namespace.yaml",
+			"csidriveroperators/ovirt/02_sa.yaml",
+			"csidriveroperators/ovirt/03_role.yaml",
+			"csidriveroperators/ovirt/04_rolebinding.yaml",
+			"csidriveroperators/ovirt/05_clusterrole.yaml",
+			"csidriveroperators/ovirt/06_clusterrolebinding.yaml",
+		},
+		CRAsset:         "csidriveroperators/ovirt/08_cr.yaml",
+		DeploymentAsset: "csidriveroperators/ovirt/07_deployment.yaml",
+		ImageReplacer:   strings.NewReplacer(pairs...),
+		ExtraControllers: []factory.Controller{
+			newOVirtCredentialsRequest(clients, recorder),
+		},
+		Optional: false,
+	}
+}
+
+func newOVirtCredentialsRequest(clients *csoclients.Clients, recorder events.Recorder) factory.Controller {
+	crController := credentialsrequestcontroller.NewCredentialsRequestController(
+		"oVirt",
+		csoclients.CSIOperatorNamespace,
+		generated.MustAsset("csidriveroperators/ovirt/09_credential_request.yaml"),
+		clients.DynamicClient,
+		clients.OperatorClient,
+		recorder)
+	return crController
+}

--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
 // CSIOperatorConfig is configuration of a CSI driver operator.
@@ -31,4 +32,6 @@ type CSIOperatorConfig struct {
 	ImageReplacer *strings.Replacer
 	// Whether the CSI driver is optional (i.e. CSO is Available / not Degraded).
 	Optional bool
+	// Extra controllers to start with the CSI driver operator
+	ExtraControllers []factory.Controller
 }

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -143,5 +143,9 @@ func (c *CSIDriverStarterController) createCSIControllerManager(
 		resyncInterval,
 	), 1)
 
+	for i := range cfg.ExtraControllers {
+		manager = manager.WithController(cfg.ExtraControllers[i], 1)
+	}
+
 	return manager
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -57,6 +57,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		// Sync with operatorv1.CSIDriverName consts!
 		{Group: operatorv1.GroupName, Resource: "clustercsidrivers", Name: string(operatorv1.AWSEBSCSIDriver)},
 		{Group: operatorv1.GroupName, Resource: "clustercsidrivers", Name: string(operatorv1.OvirtCSIDriver)},
+		{Group: operatorv1.GroupName, Resource: "clustercsidrivers", Name: string(operatorv1.ManilaCSIDriver)},
 		// TODO: remove when the driver moves to csidriveroperator.CSIOperatorNamespace
 		{Resource: "namespaces", Name: "openshift-aws-ebs-csi-driver"},
 	}
@@ -114,5 +115,6 @@ func populateConfigs(clients *csoclients.Clients, recorder events.Recorder) []cs
 	return []csioperatorclient.CSIOperatorConfig{
 		csioperatorclient.GetAWSEBSCSIOperatorConfig(),
 		csioperatorclient.GetOVirtCSIOperatorConfig(clients, recorder),
+		csioperatorclient.GetManilaOperatorConfig(clients, recorder),
 	}
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -56,6 +56,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		{Group: operatorv1.GroupName, Resource: "storages", Name: operatorclient.GlobalConfigName},
 		// Sync with operatorv1.CSIDriverName consts!
 		{Group: operatorv1.GroupName, Resource: "clustercsidrivers", Name: string(operatorv1.AWSEBSCSIDriver)},
+		{Group: operatorv1.GroupName, Resource: "clustercsidrivers", Name: string(operatorv1.OvirtCSIDriver)},
 		// TODO: remove when the driver moves to csidriveroperator.CSIOperatorNamespace
 		{Resource: "namespaces", Name: "openshift-aws-ebs-csi-driver"},
 	}
@@ -112,5 +113,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 func populateConfigs(clients *csoclients.Clients, recorder events.Recorder) []csioperatorclient.CSIOperatorConfig {
 	return []csioperatorclient.CSIOperatorConfig{
 		csioperatorclient.GetAWSEBSCSIOperatorConfig(),
+		csioperatorclient.GetOVirtCSIOperatorConfig(clients, recorder),
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller/credentials_request_controller.go
@@ -1,0 +1,98 @@
+package credentialsrequestcontroller
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	opv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// CredentialsRequestController is a simple controller that maintains a CredentialsRequest static manifest.
+// It uses unstructured.Unstructured as currently there's no API type for this resource.
+// TODO: the functionality in this controller should be moved to the StatisResourceController.
+type CredentialsRequestController struct {
+	name            string
+	operatorClient  v1helpers.OperatorClient
+	targetNamespace string
+	manifest        []byte
+	dynamicClient   dynamic.Interface
+}
+
+// NewCredentialsRequestController returns a CredentialsRequestController.
+func NewCredentialsRequestController(
+	name,
+	targetNamespace string,
+	manifest []byte,
+	dynamicClient dynamic.Interface,
+	operatorClient v1helpers.OperatorClient,
+	recorder events.Recorder,
+) factory.Controller {
+	c := &CredentialsRequestController{
+		name:            name,
+		operatorClient:  operatorClient,
+		targetNamespace: targetNamespace,
+		manifest:        manifest,
+		dynamicClient:   dynamicClient,
+	}
+	return factory.New().WithInformers(
+		operatorClient.Informer(),
+	).WithSync(
+		c.sync,
+	).ResyncEvery(
+		time.Minute,
+	).WithSyncDegradedOnError(
+		operatorClient,
+	).ToController(
+		c.name,
+		recorder.WithComponentSuffix("credentials-request-controller-"+strings.ToLower(name)),
+	)
+}
+
+func (c CredentialsRequestController) syncCredentialsRequest(
+	status *opv1.OperatorStatus,
+	syncContext factory.SyncContext,
+) (*unstructured.Unstructured, error) {
+	cr := resourceread.ReadCredentialRequestsOrDie(c.manifest)
+	err := unstructured.SetNestedField(cr.Object, c.targetNamespace, "spec", "secretRef", "namespace")
+	if err != nil {
+		return nil, err
+	}
+
+	var expectedGeneration int64 = -1
+	generation := resourcemerge.GenerationFor(
+		status.Generations,
+		schema.GroupResource{
+			Group:    resourceapply.CredentialsRequestGroup,
+			Resource: resourceapply.CredentialsRequestResource,
+		},
+		cr.GetNamespace(),
+		cr.GetName())
+	if generation != nil {
+		expectedGeneration = generation.LastGeneration
+	}
+
+	cr, _, err = resourceapply.ApplyCredentialsRequest(c.dynamicClient, syncContext.Recorder(), cr, expectedGeneration)
+	return cr, err
+}
+
+func (c CredentialsRequestController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	_, status, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		syncContext.Recorder().Warningf("StatusNotFound", "Unable to determine current operator status for %s", c.name)
+		return nil
+	}
+	_, err = c.syncCredentialsRequest(status, syncContext)
+	return err
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/core.go
@@ -1,0 +1,67 @@
+package resourcesynccontroller
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/util/cert"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func CombineCABundleConfigMaps(destinationConfigMap ResourceLocation, lister corev1listers.ConfigMapLister, inputConfigMaps ...ResourceLocation) (*corev1.ConfigMap, error) {
+	certificates := []*x509.Certificate{}
+	for _, input := range inputConfigMaps {
+		inputConfigMap, err := lister.ConfigMaps(input.Namespace).Get(input.Name)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// configmaps must conform to this
+		inputContent := inputConfigMap.Data["ca-bundle.crt"]
+		if len(inputContent) == 0 {
+			continue
+		}
+		inputCerts, err := cert.ParseCertsPEM([]byte(inputContent))
+		if err != nil {
+			return nil, fmt.Errorf("configmap/%s in %q is malformed: %v", input.Name, input.Namespace, err)
+		}
+		certificates = append(certificates, inputCerts...)
+	}
+
+	certificates = crypto.FilterExpiredCerts(certificates...)
+	finalCertificates := []*x509.Certificate{}
+	// now check for duplicates. n^2, but super simple
+	for i := range certificates {
+		found := false
+		for j := range finalCertificates {
+			if reflect.DeepEqual(certificates[i].Raw, finalCertificates[j].Raw) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			finalCertificates = append(finalCertificates, certificates[i])
+		}
+	}
+
+	caBytes, err := crypto.EncodeCertificates(finalCertificates...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: destinationConfigMap.Namespace, Name: destinationConfigMap.Name},
+		Data: map[string]string{
+			"ca-bundle.crt": string(caBytes),
+		},
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/interfaces.go
@@ -1,0 +1,19 @@
+package resourcesynccontroller
+
+// ResourceLocation describes coordinates for a resource to be synced
+type ResourceLocation struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+var emptyResourceLocation = ResourceLocation{}
+
+// ResourceSyncer allows changes to syncing rules by this controller
+type ResourceSyncer interface {
+	// SyncConfigMap indicates that a configmap should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncConfigMap(destination, source ResourceLocation) error
+	// SyncSecret indicates that a secret should be copied from the source to the destination.  It will also
+	// mirror a deletion from the source.  If the source is a zero object the destination will be deleted.
+	SyncSecret(destination, source ResourceLocation) error
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resourcesynccontroller/resourcesync_controller.go
@@ -1,0 +1,280 @@
+package resourcesynccontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/condition"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/management"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// ResourceSyncController is a controller that will copy source configmaps and secrets to their destinations.
+// It will also mirror deletions by deleting destinations.
+type ResourceSyncController struct {
+	name string
+	// syncRuleLock is used to ensure we avoid races on changes to syncing rules
+	syncRuleLock sync.RWMutex
+	// configMapSyncRules is a map from destination location to source location
+	configMapSyncRules map[ResourceLocation]ResourceLocation
+	// secretSyncRules is a map from destination location to source location
+	secretSyncRules map[ResourceLocation]ResourceLocation
+
+	// knownNamespaces is the list of namespaces we are watching.
+	knownNamespaces sets.String
+
+	configMapGetter            corev1client.ConfigMapsGetter
+	secretGetter               corev1client.SecretsGetter
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces
+	operatorConfigClient       v1helpers.OperatorClient
+
+	runFn   func(ctx context.Context, workers int)
+	syncCtx factory.SyncContext
+}
+
+var _ ResourceSyncer = &ResourceSyncController{}
+var _ factory.Controller = &ResourceSyncController{}
+
+// NewResourceSyncController creates ResourceSyncController.
+func NewResourceSyncController(
+	operatorConfigClient v1helpers.OperatorClient,
+	kubeInformersForNamespaces v1helpers.KubeInformersForNamespaces,
+	secretsGetter corev1client.SecretsGetter,
+	configMapsGetter corev1client.ConfigMapsGetter,
+	eventRecorder events.Recorder,
+) *ResourceSyncController {
+	c := &ResourceSyncController{
+		name:                 "ResourceSyncController",
+		operatorConfigClient: operatorConfigClient,
+
+		configMapSyncRules:         map[ResourceLocation]ResourceLocation{},
+		secretSyncRules:            map[ResourceLocation]ResourceLocation{},
+		kubeInformersForNamespaces: kubeInformersForNamespaces,
+		knownNamespaces:            kubeInformersForNamespaces.Namespaces(),
+
+		configMapGetter: configMapsGetter,
+		secretGetter:    secretsGetter,
+		syncCtx:         factory.NewSyncContext("ResourceSyncController", eventRecorder.WithComponentSuffix("resource-sync-controller")),
+	}
+
+	informers := []factory.Informer{
+		operatorConfigClient.Informer(),
+	}
+	for namespace := range kubeInformersForNamespaces.Namespaces() {
+		if len(namespace) == 0 {
+			continue
+		}
+		informer := kubeInformersForNamespaces.InformersFor(namespace)
+		informers = append(informers, informer.Core().V1().ConfigMaps().Informer())
+		informers = append(informers, informer.Core().V1().Secrets().Informer())
+	}
+
+	f := factory.New().WithSync(c.Sync).WithSyncContext(c.syncCtx).WithInformers(informers...).ResyncEvery(time.Second).ToController(c.name, eventRecorder.WithComponentSuffix("resource-sync-controller"))
+	c.runFn = f.Run
+
+	return c
+}
+
+func (c *ResourceSyncController) Run(ctx context.Context, workers int) {
+	c.runFn(ctx, workers)
+}
+
+func (c *ResourceSyncController) Name() string {
+	return c.name
+}
+
+func (c *ResourceSyncController) SyncConfigMap(destination, source ResourceLocation) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.configMapSyncRules[destination] = source
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) SyncSecret(destination, source ResourceLocation) error {
+	if !c.knownNamespaces.Has(destination.Namespace) {
+		return fmt.Errorf("not watching namespace %q", destination.Namespace)
+	}
+	if source != emptyResourceLocation && !c.knownNamespaces.Has(source.Namespace) {
+		return fmt.Errorf("not watching namespace %q", source.Namespace)
+	}
+
+	c.syncRuleLock.Lock()
+	defer c.syncRuleLock.Unlock()
+	c.secretSyncRules[destination] = source
+
+	// make sure the new rule is picked up
+	c.syncCtx.Queue().Add(c.syncCtx.QueueKey())
+	return nil
+}
+
+func (c *ResourceSyncController) Sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	operatorSpec, _, _, err := c.operatorConfigClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	if !management.IsOperatorManaged(operatorSpec.ManagementState) {
+		return nil
+	}
+
+	c.syncRuleLock.RLock()
+	defer c.syncRuleLock.RUnlock()
+
+	errors := []error{}
+
+	for destination, source := range c.configMapSyncRules {
+		if source == emptyResourceLocation {
+			// use the cache to check whether the configmap exists in target namespace, if not skip the extra delete call.
+			if _, err := c.configMapGetter.ConfigMaps(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.configMapGetter.ConfigMaps(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncConfigMap(c.configMapGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	for destination, source := range c.secretSyncRules {
+		if source == emptyResourceLocation {
+			// use the cache to check whether the secret exists in target namespace, if not skip the extra delete call.
+			if _, err := c.secretGetter.Secrets(destination.Namespace).Get(ctx, destination.Name, metav1.GetOptions{}); err != nil {
+				if !apierrors.IsNotFound(err) {
+					errors = append(errors, err)
+				}
+				continue
+			}
+			if err := c.secretGetter.Secrets(destination.Namespace).Delete(ctx, destination.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+				errors = append(errors, err)
+			}
+			continue
+		}
+
+		_, _, err := resourceapply.SyncSecret(c.secretGetter, syncCtx.Recorder(), source.Namespace, source.Name, destination.Namespace, destination.Name, []metav1.OwnerReference{})
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+
+	if len(errors) > 0 {
+		cond := operatorv1.OperatorCondition{
+			Type:    condition.ResourceSyncControllerDegradedConditionType,
+			Status:  operatorv1.ConditionTrue,
+			Reason:  "Error",
+			Message: v1helpers.NewMultiLineAggregate(errors).Error(),
+		}
+		if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+			return updateError
+		}
+		return nil
+	}
+
+	cond := operatorv1.OperatorCondition{
+		Type:   condition.ResourceSyncControllerDegradedConditionType,
+		Status: operatorv1.ConditionFalse,
+	}
+	if _, _, updateError := v1helpers.UpdateStatus(c.operatorConfigClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+	return nil
+}
+
+func NewDebugHandler(controller *ResourceSyncController) http.Handler {
+	return &debugHTTPHandler{controller: controller}
+}
+
+type debugHTTPHandler struct {
+	controller *ResourceSyncController
+}
+
+type ResourceSyncRule struct {
+	Source      ResourceLocation `json:"source"`
+	Destination ResourceLocation `json:"destination"`
+}
+
+type ResourceSyncRuleList []ResourceSyncRule
+
+func (l ResourceSyncRuleList) Len() int      { return len(l) }
+func (l ResourceSyncRuleList) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l ResourceSyncRuleList) Less(i, j int) bool {
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) < 0 {
+		return true
+	}
+	if strings.Compare(l[i].Source.Namespace, l[j].Source.Namespace) > 0 {
+		return false
+	}
+	if strings.Compare(l[i].Source.Name, l[j].Source.Name) < 0 {
+		return true
+	}
+	return false
+}
+
+type ControllerSyncRules struct {
+	Secrets ResourceSyncRuleList `json:"secrets"`
+	Configs ResourceSyncRuleList `json:"configs"`
+}
+
+// ServeSyncRules provides a handler function to return the sync rules of the controller
+func (h *debugHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	syncRules := ControllerSyncRules{ResourceSyncRuleList{}, ResourceSyncRuleList{}}
+
+	h.controller.syncRuleLock.RLock()
+	defer h.controller.syncRuleLock.RUnlock()
+	syncRules.Secrets = append(syncRules.Secrets, resourceSyncRuleList(h.controller.secretSyncRules)...)
+	syncRules.Configs = append(syncRules.Configs, resourceSyncRuleList(h.controller.configMapSyncRules)...)
+
+	data, err := json.Marshal(syncRules)
+	if err != nil {
+		w.Write([]byte(err.Error()))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+	w.WriteHeader(http.StatusOK)
+}
+
+func resourceSyncRuleList(syncRules map[ResourceLocation]ResourceLocation) ResourceSyncRuleList {
+	rules := make(ResourceSyncRuleList, 0, len(syncRules))
+	for src, dest := range syncRules {
+		rule := ResourceSyncRule{
+			Source:      src,
+			Destination: dest,
+		}
+		rules = append(rules, rule)
+	}
+	sort.Sort(rules)
+	return rules
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,6 +199,7 @@ github.com/openshift/library-go/pkg/controller/manager
 github.com/openshift/library-go/pkg/controller/metrics
 github.com/openshift/library-go/pkg/crypto
 github.com/openshift/library-go/pkg/operator/condition
+github.com/openshift/library-go/pkg/operator/csi/credentialsrequestcontroller
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/loglevel
 github.com/openshift/library-go/pkg/operator/management
@@ -206,6 +207,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourceapply
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
+github.com/openshift/library-go/pkg/operator/resourcesynccontroller
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers


### PR DESCRIPTION
* oVirt is simple
* Manila is an optional CSI driver.
  * If underlying cloud has Manila, everything is the same as for the other (mandatory) drivers
  * If there is no Manila, Manila operator reports condition `Disabled: true`. CSO then consumes it and reports `Available: true` (because there is nothing wrong in the cluster). User can get details about Manila in `Storage` CR.

@openshift/storage 

/hold
requires https://github.com/openshift/csi-driver-manila-operator/pull/44 merged first