### PR TITLE
Fix NFS driver deployment

### DIFF
--- a/manifests/04_deployment.yaml
+++ b/manifests/04_deployment.yaml
@@ -57,7 +57,7 @@ spec:
             value: quay.io/openshift/origin-csi-driver-manila-operator:latest
           - name: MANILA_DRIVER_IMAGE
             value: quay.io/openshift/origin-csi-driver-manila:latest
-          - name: MANILA_NSF_DRIVER_IMAGE
+          - name: MANILA_NFS_DRIVER_IMAGE
             value: quay.io/openshift/origin-csi-driver-nfs:latest
           - name: PROVISIONER_IMAGE
             value: quay.io/openshift/origin-csi-external-provisioner:latest


### PR DESCRIPTION
Pass NFS driver image name to Manila operator.

Fixes this error in Manila CSI driver Deployment:
```
    Failed to apply default image tag "${NFS_DRIVER_IMAGE}": couldn't parse
    image reference "${NFS_DRIVER_IMAGE}": invalid reference format:
    repository name must be lowercase
```

@openshift/storage 