### PR TITLE
Move to openshift-manila-csi-driver namespace

### DIFF
--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -76,6 +76,10 @@ rules:
   - get
   - list
   - watch
+  # For CA certificate sync
+  - create
+  - patch
+  - update
 - apiGroups:
   - ''
   resources:

--- a/assets/csidriveroperators/manila/09_credentials.yaml
+++ b/assets/csidriveroperators/manila/09_credentials.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-manila-csi-driver
+  name: openshift-manila-csi-driver-operator
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -807,6 +807,10 @@ rules:
   - get
   - list
   - watch
+  # For CA certificate sync
+  - create
+  - patch
+  - update
 - apiGroups:
   - ''
   resources:
@@ -1136,7 +1140,7 @@ func csidriveroperatorsManila08_crYaml() (*asset, error) {
 var _csidriveroperatorsManila09_credentialsYaml = []byte(`apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-manila-csi-driver
+  name: openshift-manila-csi-driver-operator
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:


### PR DESCRIPTION
As Manila CSI driver moves to openshift-manila-csi-driver, CSO must update
some code too:

- Manila operator must have permissions to create/update secrets in openshift-manila-csi-driver namespace to be able to translate OpenStack credentials to the format required by Manila.
- Manila operator will need to create CredentialsRequest for the driver (because now it's in a separate NS). Therefore CSO should use another name for the operator's CredentialsRequest, so the name implies it's for the operator only.