### PR TITLE
Fix reporting Available: true too early

### DIFF
--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	conditionsPrefix      = "DefaultStorageClassController"
+	ConditionsPrefix      = "DefaultStorageClassController"
 	infraConfigName       = "cluster"
 	disabledConditionType = "Disabled"
 )
@@ -76,11 +76,11 @@ func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) erro
 	}
 
 	availableCnd := operatorapi.OperatorCondition{
-		Type:   conditionsPrefix + operatorapi.OperatorStatusTypeAvailable,
+		Type:   ConditionsPrefix + operatorapi.OperatorStatusTypeAvailable,
 		Status: operatorapi.ConditionTrue,
 	}
 	progressingCnd := operatorapi.OperatorCondition{
-		Type:   conditionsPrefix + operatorapi.OperatorStatusTypeProgressing,
+		Type:   ConditionsPrefix + operatorapi.OperatorStatusTypeProgressing,
 		Status: operatorapi.ConditionFalse,
 	}
 
@@ -89,7 +89,7 @@ func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) erro
 		if syncErr == unsupportedPlatformError {
 			// Set Disabled condition - there is nothing to do
 			disabledCnd := operatorapi.OperatorCondition{
-				Type:    conditionsPrefix + disabledConditionType,
+				Type:    ConditionsPrefix + disabledConditionType,
 				Status:  operatorapi.ConditionTrue,
 				Reason:  "UnsupportedPlatform",
 				Message: syncErr.Error(),
@@ -121,7 +121,7 @@ func (c *Controller) sync(ctx context.Context, syncCtx factory.SyncContext) erro
 	if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient,
 		v1helpers.UpdateConditionFn(availableCnd),
 		v1helpers.UpdateConditionFn(progressingCnd),
-		removeConditionFn(conditionsPrefix+disabledConditionType),
+		removeConditionFn(ConditionsPrefix+disabledConditionType),
 	); updateErr != nil {
 		return errutil.NewAggregate([]error{syncErr, updateErr})
 	}

--- a/pkg/operator/defaultstorageclass/controller_test.go
+++ b/pkg/operator/defaultstorageclass/controller_test.go
@@ -149,8 +149,8 @@ func TestSync(t *testing.T) {
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withTrueConditions(ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 				storageClasses: []*storagev1.StorageClass{getPlatformStorageClass("storageclasses/aws.yaml")},
 			},
@@ -165,8 +165,8 @@ func TestSync(t *testing.T) {
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+"Disabled", conditionsPrefix+opv1.OperatorStatusTypeAvailable),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withTrueConditions(ConditionsPrefix+"Disabled", ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 			},
 			expectErr: false,
@@ -176,16 +176,16 @@ func TestSync(t *testing.T) {
 			name: "everything deployed",
 			initialObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withTrueConditions(ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 				storageClasses: []*storagev1.StorageClass{getPlatformStorageClass("storageclasses/aws.yaml")},
 				infrastructure: getInfrastructure(cfgv1.AWSPlatformType),
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withTrueConditions(ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 				storageClasses: []*storagev1.StorageClass{getPlatformStorageClass("storageclasses/aws.yaml")},
 			},
@@ -201,8 +201,8 @@ func TestSync(t *testing.T) {
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withTrueConditions(ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
 				),
 				storageClasses: []*storagev1.StorageClass{getPlatformStorageClass("storageclasses/aws.yaml", withNoDefault)},
 			},
@@ -216,8 +216,8 @@ func TestSync(t *testing.T) {
 			},
 			expectedObjects: testObjects{
 				storage: getCR(
-					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
-					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withTrueConditions(ConditionsPrefix+opv1.OperatorStatusTypeProgressing),
+					withFalseConditions(ConditionsPrefix+opv1.OperatorStatusTypeAvailable),
 				),
 			},
 			expectErr: true,


### PR DESCRIPTION
To make sure that `Available: true` is reported after *all* controllers had a chance to sync their status, set `Available: Unknown` to all unset conditions.

CSIDriverStarter then cleans those that are not relevant to the target platform.

@openshift/storage 