### PR TITLE
Bug 1867704: Give pod listing permissions to aws operator

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -130,6 +130,14 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - persistentvolumeclaims/status
   verbs:
   - patch

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -346,6 +346,14 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - persistentvolumeclaims/status
   verbs:
   - patch


### PR DESCRIPTION
Please note this is a temporary measure, I intend to remove these permissions and disable the support for volume-in-use error in resizer for EBS because it is not applicable.

However, without this fix - we have a chicken and egg problem. The rebase PR of external-resizer will not merge until external-resizer can list the pods.
