### PR TITLE
Bug 1867735: Fix syncing of Manila CA certificate

### DIFF
--- a/pkg/csoclients/csoclients.go
+++ b/pkg/csoclients/csoclients.go
@@ -46,6 +46,7 @@ type Clients struct {
 const (
 	OperatorNamespace    = "openshift-cluster-storage-operator"
 	CSIOperatorNamespace = "openshift-cluster-csi-drivers"
+	CloudConfigNamespace = "openshift-config"
 )
 
 var (
@@ -53,6 +54,7 @@ var (
 		"", // For non-namespaced objects
 		OperatorNamespace,
 		CSIOperatorNamespace,
+		CloudConfigNamespace,
 	}
 )
 


### PR DESCRIPTION
The sync failed, because CSO's KubeInformersForNamespaces did not watch openshift-config namespace.

Add the namespace to the namespace list + make sure that CSO panics on similar errors in future.
