### PR TITLE
Bug 1869516: Prevent crash if PlatformStatus is nil

### DIFF
--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -134,6 +134,11 @@ func (c *Controller) syncStorageClass() error {
 	if err != nil {
 		return err
 	}
+	// Check to see if the PlatformStatus is nil. This has been seen on some
+	// UPI installs on baremetal platforms
+	if infrastructure.Status.PlatformStatus == nil {
+		return unsupportedPlatformError
+	}
 
 	expectedSC, err := newStorageClassForCluster(infrastructure)
 	if err != nil {


### PR DESCRIPTION
There was an issue in [BZ1869516](https://bugzilla.redhat.com/show_bug.cgi?id=1869516) where the CSO paniced during an upgrade on a baremetal UPI cluster. When examining the Infrastructure resource, there was no PlatformStatus defined.

This should check and return an unsupportedPlatform if the PlatformStatus is nil.