### PR TITLE
Bug 1871051: Add CSI operators permissions to patch volumeattachment/status

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -164,6 +164,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotcontents/status

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -139,6 +139,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotcontents/status

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -380,6 +380,12 @@ rules:
   - create
   - patch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
   - snapshot.storage.k8s.io
   resources:
   - volumesnapshotcontents/status
@@ -1451,6 +1457,12 @@ rules:
   - update
   - delete
   - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
   - patch
 - apiGroups:
   - snapshot.storage.k8s.io


### PR DESCRIPTION
The external-attacher needs to patch volumeattachment/status. Add such permission to AWS EBS and oVirt operators, so they're able to grant it to the driver.

@openshift/storage 