### PR TITLE
Bug 1868339: Rename Manila CredentialsRequest to a name similar to the other ones

### DIFF
--- a/manifests/03_credentials_request_openstack.yaml
+++ b/manifests/03_credentials_request_openstack.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-manila-csi-driver-operator
+  name: manila-csi-driver-operator
   namespace: openshift-cloud-credential-operator
 spec:
   secretRef:


### PR DESCRIPTION
```
$ oc get credentialsrequests.cloudcredential.openshift.io -A | grep csi
openshift-cloud-credential-operator   aws-ebs-csi-driver-operator           
openshift-cloud-credential-operator   ovirt-csi-driver-operator             
openshift-cloud-credential-operator   openshift-manila-csi-driver-operator  
```

Rename to `manila-csi-driver-operator`.

CC @openshift/storage

