### PR TITLE
Bug 1879365: Move CSO namespace to lower runlevel

### DIFF
--- a/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
+++ b/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
@@ -1,0 +1,9 @@
+# Create the namespace at runlevel 49, so cluster-csi-snapshot-controller-operator (running at level 50) can use it.
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-cluster-storage-operator

--- a/manifests/01_operator_namespace.yaml
+++ b/manifests/01_operator_namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/node-selector: ""
-  name: openshift-cluster-storage-operator


### PR DESCRIPTION
cluster-storage-operator and cluster-csi-snapshot-controller-operator both run at runlevel 50 and in the same namespace. Create the namespace at runlevel 49, so the namespace is created only once and the authoritative version is in this repo.

The namespace creation will be removed from cluster-csi-snapshot-controller-operator in a subsequent PR.