### PR TITLE
Bug 1882394: UPSTREAM: <carry>: operator-sdk: return error if lock is not leader-for-life

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,6 +36,10 @@ required = [
   version = "=v0.1.8"
 
 [[constraint]]
+  # WARNING: don't update operator-sdk.
+  # There's a patch in ./vendor intended to workaround
+  # a 4.6 -> 4.5 downgrade issue. See:
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1882394
   name = "github.com/operator-framework/operator-sdk"
   version = "=v0.4.0" #osdk_version_annotation
 


### PR DESCRIPTION
In a 4.6 -> 4.5 downgrade scenario, CSO 4.5 could be started before CSO 4.6 is terminated.

This could happen:

1. CSO 4.6 creates a _leader_with_lease_ `ConfigMap`
2. User downgrades to OCP 4.5
3. CSO 4.5 starts and sees that the existing `ConfigMap` was created by CSO 4.6, so it deletes it and continues to initialize
4. CSO 4.6 sees that its _leader_with_lease_ `ConfigMap` was deleted and quickly re-created it
5. CSO 4.5 is still starting up. Now it tries to become the leader by creating the _leader_for_life_ `ConfigMap`, but that fails because another object with the same name exists
6. CSO 4.5 (i.e., operator-sdk) gets stuck in a loop trying to create the lock, but it fails forever

This patch introduces a check in the legacy operator-sdk code to prevent CSO 4.5 from getting stuck in the loop described in step 6 above.