### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
+++ b/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-cluster-storage-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -26,6 +27,7 @@ metadata:
   namespace: openshift-cluster-storage-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-storage-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_cluster-storage-operator_02_servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/02_csi_driver_operators_namespace.yaml
+++ b/manifests/02_csi_driver_operators_namespace.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: ebs-cloud-credentials

--- a/manifests/03_credentials_request_cinder.yaml
+++ b/manifests/03_credentials_request_cinder.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: openstack-cloud-credentials

--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: gcp-pd-cloud-credentials

--- a/manifests/03_credentials_request_manila.yaml
+++ b/manifests/03_credentials_request_manila.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: manila-cloud-credentials

--- a/manifests/03_credentials_request_ovirt.yaml
+++ b/manifests/03_credentials_request_ovirt.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/manifests/03_credentials_request_vsphere.yaml
+++ b/manifests/03_credentials_request_vsphere.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   secretRef:
     name: vsphere-cloud-credentials

--- a/manifests/06_operator_cr.yaml
+++ b/manifests/06_operator_cr.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/07_service_account.yaml
+++ b/manifests/07_service_account.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/08_operator_rbac.yaml
+++ b/manifests/08_operator_rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
   - kind: ServiceAccount
     name: cluster-storage-operator

--- a/manifests/09_metrics_service.yaml
+++ b/manifests/09_metrics_service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: cluster-storage-operator-serving-cert
   labels:
     app: cluster-storage-operator-metrics

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/11_cluster_operator.yaml
+++ b/manifests/11_cluster_operator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   managementState: Managed
 status:


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-storage-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.