### PR TITLE
Bug 1902601: Fix resources in cinder csi deployment template

### DIFF
--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -39,6 +39,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: openstack-cinder-csi-driver-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
       priorityClassName: system-cluster-critical
       serviceAccountName: openstack-cinder-csi-driver-operator
       nodeSelector:
@@ -49,7 +53,3 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
-      resources:
-        requests:
-          cpu: 10m
-          memory: 20Mi

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -2200,6 +2200,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: openstack-cinder-csi-driver-operator
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
       priorityClassName: system-cluster-critical
       serviceAccountName: openstack-cinder-csi-driver-operator
       nodeSelector:
@@ -2210,10 +2214,6 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
-      resources:
-        requests:
-          cpu: 10m
-          memory: 20Mi
 `)
 
 func csidriveroperatorsOpenstackCinder07_deploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This should fix the "Managed cluster should ensure control plane pods do
not run in best-effort QoS" CI test that is currently failing with:

    5 pods found in best-effort QoS:
    openshift-cluster-csi-drivers/openstack-cinder-csi-driver-controller-5bfc8fdf46-k9h6f is running in best-effort QoS
    openshift-cluster-csi-drivers/openstack-cinder-csi-driver-node-gqmzg is running in best-effort QoS
    openshift-cluster-csi-drivers/openstack-cinder-csi-driver-node-hn5pp is running in best-effort QoS
    openshift-cluster-csi-drivers/openstack-cinder-csi-driver-node-nsffx is running in best-effort QoS
    openshift-cluster-csi-drivers/openstack-cinder-csi-driver-operator-7f968db7f-hkvmj is running in best-effort QoS

https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.7/1334497702402068480