### PR TITLE
support custom CA bundle for AWS API

### DIFF
--- a/assets/csidriveroperators/aws-ebs/07_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/07_deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: CA_BUNDLE_CONFIG_MAP
+          value: ${CA_BUNDLE_CONFIG_MAP}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/csoclients/csoclients.go
+++ b/pkg/csoclients/csoclients.go
@@ -44,9 +44,10 @@ type Clients struct {
 }
 
 const (
-	OperatorNamespace    = "openshift-cluster-storage-operator"
-	CSIOperatorNamespace = "openshift-cluster-csi-drivers"
-	CloudConfigNamespace = "openshift-config"
+	OperatorNamespace           = "openshift-cluster-storage-operator"
+	CSIOperatorNamespace        = "openshift-cluster-csi-drivers"
+	CloudConfigNamespace        = "openshift-config"
+	CloudConfigManagedNamespace = "openshift-config-managed"
 )
 
 var (
@@ -55,6 +56,7 @@ var (
 		OperatorNamespace,
 		CSIOperatorNamespace,
 		CloudConfigNamespace,
+		CloudConfigManagedNamespace,
 	}
 )
 

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -570,6 +570,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: CA_BUNDLE_CONFIG_MAP
+          value: ${CA_BUNDLE_CONFIG_MAP}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/operator/csidriveroperator/csioperatorclient/aws.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/aws.go
@@ -1,22 +1,40 @@
 package csioperatorclient
 
 import (
+	"context"
 	"os"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 )
 
 const (
+	cloudConfigName = "kube-cloud-config"
+	caBundleKey     = "ca-bundle.pem"
+
 	AWSEBSCSIDriverName          = "ebs.csi.aws.com"
 	envAWSEBSDriverOperatorImage = "AWS_EBS_DRIVER_OPERATOR_IMAGE"
 	envAWSEBSDriverImage         = "AWS_EBS_DRIVER_IMAGE"
 )
 
-func GetAWSEBSCSIOperatorConfig() CSIOperatorConfig {
+func GetAWSEBSCSIOperatorConfig(clients *csoclients.Clients, recorder events.Recorder) CSIOperatorConfig {
+	caBundleConfigMap := ""
+	if isCustomCABundleUsed(clients) {
+		caBundleConfigMap = cloudConfigName
+	}
+
 	pairs := []string{
 		"${OPERATOR_IMAGE}", os.Getenv(envAWSEBSDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envAWSEBSDriverImage),
+		"${CA_BUNDLE_CONFIG_MAP}", caBundleConfigMap,
 	}
 
 	return CSIOperatorConfig{
@@ -34,7 +52,10 @@ func GetAWSEBSCSIOperatorConfig() CSIOperatorConfig {
 		CRAsset:         "csidriveroperators/aws-ebs/08_cr.yaml",
 		DeploymentAsset: "csidriveroperators/aws-ebs/07_deployment.yaml",
 		ImageReplacer:   strings.NewReplacer(pairs...),
-		Optional:        false,
+		ExtraControllers: []factory.Controller{
+			newAWSTrustBundleSyncerOrDie(clients, recorder),
+		},
+		Optional: false,
 		/* For reference / experiments only. OpenShift does not support
 		   update from OLM-based AWS EBS operator to CVO/CSO one.
 		OLMOptions: &OLMOptions{
@@ -48,4 +69,46 @@ func GetAWSEBSCSIOperatorConfig() CSIOperatorConfig {
 		},
 		*/
 	}
+}
+
+func newAWSTrustBundleSyncerOrDie(clients *csoclients.Clients, recorder events.Recorder) factory.Controller {
+	// sync config map with additional trust bundle to the operator namespace,
+	// so the operator can get it as a ConfigMap volume.
+	srcConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: csoclients.CloudConfigManagedNamespace,
+		Name:      cloudConfigName,
+	}
+	dstConfigMap := resourcesynccontroller.ResourceLocation{
+		Namespace: csoclients.CSIOperatorNamespace,
+		Name:      cloudConfigName,
+	}
+	certController := resourcesynccontroller.NewResourceSyncController(
+		clients.OperatorClient,
+		clients.KubeInformers,
+		clients.KubeClient.CoreV1(),
+		clients.KubeClient.CoreV1(),
+		recorder)
+	err := certController.SyncConfigMap(dstConfigMap, srcConfigMap)
+	if err != nil {
+		// This can fail if provided clients.KubeInformers does not watch requested namespaces,
+		// which is programmatic error.
+		klog.Fatalf("Failed to start the AWS CA certificate sync controller: %s", err)
+	}
+	return certController
+}
+
+// isCustomCABundleUsed returns true
+func isCustomCABundleUsed(clients *csoclients.Clients) bool {
+	cloudConfigCM, err := clients.KubeClient.CoreV1().
+		ConfigMaps(csoclients.CloudConfigManagedNamespace).
+		Get(context.Background(), cloudConfigName, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// no cloud config ConfigMap so there is no CA bundle
+		return false
+	}
+	if err != nil {
+		klog.Fatalf("Failed to get the %s/%s ConfigMap", csoclients.CloudConfigManagedNamespace, cloudConfigName)
+	}
+	_, exists := cloudConfigCM.Data[caBundleKey]
+	return exists
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -115,7 +115,7 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 
 func populateConfigs(clients *csoclients.Clients, recorder events.Recorder) []csioperatorclient.CSIOperatorConfig {
 	return []csioperatorclient.CSIOperatorConfig{
-		csioperatorclient.GetAWSEBSCSIOperatorConfig(),
+		csioperatorclient.GetAWSEBSCSIOperatorConfig(clients, recorder),
 		csioperatorclient.GetGCPPDCSIOperatorConfig(),
 		csioperatorclient.GetOpenStackCinderCSIOperatorConfig(clients, recorder),
 		csioperatorclient.GetOVirtCSIOperatorConfig(clients, recorder),


### PR DESCRIPTION
When a cluster is installed in a AWS C2S region, access to the AWS API requires a custom CA bundle for trust. The custom CA bundle is read from the "ca-bundle.pem" key of the kube-cloud-config ConfigMap in the openshift-config-managed namespace.

To make the custom CA bundle available for use by the EBS CSI driver, the operator will sync the kube-cloud-config ConfigMap into the openshift-cluster-csi-drivers namespace. The EBS CSI driver operator is responsible for adjusting the deployment for the driver to mount the CA bundle and add the appropriate environment variable.

To inform the EBS CSI driver operator that there is a custom CA bundle, the operator will set the CA_BUNDLE_CONFIG_MAP environment variable to the name of the kube-cloud-config ConfigMap.

https://issues.redhat.com/browse/CORS-1584