### PR TITLE
Add YAMLs for starting vsphere-problem-detector as a deployment

### DIFF
--- a/manifests/03_credentials_request_vsphere.yaml
+++ b/manifests/03_credentials_request_vsphere.yaml
@@ -1,0 +1,12 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-vsphere-problem-detector
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: vsphere-cloud-credentials
+    namespace: openshift-cluster-storage-operator
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: VSphereProviderSpec

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -85,3 +85,16 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+        - name: vsphere-problem-detector
+          image: quay.io/openshift/origin-vsphere-problem-detector:latest
+          args:
+          - start
+          - --listen=0.0.0.0:8444
+          ports:
+          - containerPort: 8444
+            name: metrics
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 10m
+              memory: 100Mi

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -74,3 +74,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-csi-livenessprobe:latest
+  - name: vsphere-problem-detector
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-vsphere-problem-detector:latest


### PR DESCRIPTION
Deploy vsphere problem detector as a sidecar.

About metrics - I am wondering if same operator can have two endpoints that can be scraped by prometheus. Looking into existing operators that use `ServiceMonitor` , I don't find any example of this happening.

