### PR TITLE
aws: grant ebs operator permission to read configmaps

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -89,6 +89,14 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -322,6 +322,14 @@ rules:
 - apiGroups:
   - ''
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
To support custom CA bundles for AWS C2s, the AWS EBS opreator needs to sync the cloud config ConfigMap from the openshift-config-managed namespace into the operator's namespace.

https://issues.redhat.com/browse/CORS-1584