### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
+++ b/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-storage-operator

--- a/manifests/02_csi_driver_operators_namespace.yaml
+++ b/manifests/02_csi_driver_operators_namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: ebs-cloud-credentials

--- a/manifests/03_credentials_request_cinder.yaml
+++ b/manifests/03_credentials_request_cinder.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: openstack-cloud-credentials

--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: gcp-pd-cloud-credentials

--- a/manifests/03_credentials_request_manila.yaml
+++ b/manifests/03_credentials_request_manila.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   secretRef:
     name: manila-cloud-credentials

--- a/manifests/03_credentials_request_ovirt.yaml
+++ b/manifests/03_credentials_request_ovirt.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1

--- a/manifests/06_operator_cr.yaml
+++ b/manifests/06_operator_cr.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed
   logLevel: Normal

--- a/manifests/07_service_account.yaml
+++ b/manifests/07_service_account.yaml
@@ -6,3 +6,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/08_operator_rbac.yaml
+++ b/manifests/08_operator_rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
   - kind: ServiceAccount
     name: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/11_cluster_operator.yaml
+++ b/manifests/11_cluster_operator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed
 status:


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.