### PR TITLE
Bug 1907329: Add missing default cluster profile annotation

### DIFF
--- a/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata:
   name: prometheus
   namespace: openshift-cluster-storage-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
   - ""
@@ -22,6 +24,8 @@ kind: RoleBinding
 metadata:
   name: prometheus
   namespace: openshift-cluster-storage-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/03_credentials_request_vsphere.yaml
+++ b/manifests/03_credentials_request_vsphere.yaml
@@ -3,6 +3,8 @@ kind: CredentialsRequest
 metadata:
   name: openshift-vsphere-problem-detector
   namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   secretRef:
     name: vsphere-cloud-credentials


### PR DESCRIPTION
A PR was merged with new manifests that don't contain default annotation. 