### PR TITLE
Bug 1909978: specify availability zone for OpenStack SC

### DIFF
--- a/assets/storageclasses/openstack.yaml
+++ b/assets/storageclasses/openstack.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/cinder
+parameters:
+  availability: nova
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -2969,6 +2969,8 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/cinder
+parameters:
+  availability: nova
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 reclaimPolicy: Delete


### PR DESCRIPTION
The absence of "availability" parameter in the storage class prevents users from setting "ignore-volume-az = yes" in the cloud provider config.