### PR TITLE
Bug 1912945: Add RBAC rules to read proxy resource

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -260,6 +260,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
+++ b/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
@@ -252,6 +252,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -238,6 +238,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
@@ -252,6 +252,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -233,6 +233,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -501,6 +501,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list
@@ -1036,6 +1037,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list
@@ -1555,6 +1557,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list
@@ -2118,6 +2121,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list
@@ -2645,6 +2649,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list


### PR DESCRIPTION
This will be necessary so that CSI driver operators can read the proxy object.

CC @openshift/storage
