### PR TITLE
Bug 1914451: Run CSO as non-root user

### DIFF
--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -32,6 +32,10 @@ spec:
         tolerationSeconds: 120 # Evict pods within 2 mins.
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-storage-operator
+      securityContext:
+        fsGroup: 10400
+        runAsGroup: 10400
+        runAsUser: 10400
       containers:
         - name: cluster-storage-operator
           image: quay.io/openshift/origin-cluster-storage-operator:latest


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1914451

cc @sttts @openshift/storage 

After the change:

```
~> oc exec cluster-storage-operator-77b4cffccb-bmtgb -i -t -- whoami
10400
```


