### PR TITLE
Bug 1912945: Add RBAC to allow operator to update CR's spec

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:

--- a/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
+++ b/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -247,4 +247,6 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
   - update
+  - patch

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -263,6 +263,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -861,6 +864,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -2722,7 +2728,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
   - update
+  - patch
 `)
 
 func csidriveroperatorsOvirt05_clusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
The Config Observer controller from CSI driver operators `1)` watches the `proxies` resource and `2)` patches/updates the `CR.Spec.ObservedConfig`.

PR https://github.com/openshift/cluster-storage-operator/pull/121 introduced the RBAC rule for `#1`, but it missed the rule for `#2`.

CC @openshift/storage
