### PR TITLE
vsphere: don't redeploy StorageClass in every sync

### DIFF
--- a/assets/storageclasses/vsphere.yaml
+++ b/assets/storageclasses/vsphere.yaml
@@ -8,3 +8,4 @@ provisioner: kubernetes.io/vsphere-volume
 parameters:
   diskformat: thin
 reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -3073,6 +3073,7 @@ provisioner: kubernetes.io/vsphere-volume
 parameters:
   diskformat: thin
 reclaimPolicy: Delete
+volumeBindingMode: Immediate
 `)
 
 func storageclassesVsphereYamlBytes() ([]byte, error) {


### PR DESCRIPTION
library-go compares the existing + expected StorageClass without defaulting, therefore thinking that `volumeBindingMode: Immediate` and `volumeBindingMode: nil` are different and re-deploying the storage class with every sync (10 minutes).

Update the vSphere StorageClass with the binding mode to make the comparison work.