### PR TITLE
Bug 1905141: Fix alerting rule of vsphere-problem-detector

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -10,14 +10,14 @@ spec:
     - name: vsphere-problem-detector.rules
       rules:
       - alert: VSphereOpenshiftNodeHealthFail
-        expr:  vsphere_node_check_errors == 1
+        expr:  min_over_time(vsphere_node_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning
         annotations:
           message: "VSphere health check {{ $labels.check }} is failing on {{ $labels.node }}."
       - alert: VSphereOpenshiftClusterHealthFail
-        expr: vsphere_cluster_check_errors == 1
+        expr: min_over_time(vsphere_cluster_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -3468,14 +3468,14 @@ spec:
     - name: vsphere-problem-detector.rules
       rules:
       - alert: VSphereOpenshiftNodeHealthFail
-        expr:  vsphere_node_check_errors == 1
+        expr:  min_over_time(vsphere_node_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning
         annotations:
           message: "VSphere health check {{ $labels.check }} is failing on {{ $labels.node }}."
       - alert: VSphereOpenshiftClusterHealthFail
-        expr: vsphere_cluster_check_errors == 1
+        expr: min_over_time(vsphere_cluster_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
When vsphere-problem-detector's prometheus endpoint is down from any reason (e.g. update), Prometheus will report "no data" for `vsphere_*_check_errors` and therefore clear any current alert.

Using `min_over_time[5m]` will ensure that such "no data" holes are skipped.