### PR TITLE
Bug 1923098: Add replicasets to vsphere permissions

### DIFF
--- a/assets/vsphere_problem_detector/02_role.yaml
+++ b/assets/vsphere_problem_detector/02_role.yaml
@@ -26,6 +26,7 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -3140,6 +3140,7 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
Currently the vsphere problem detector logs this on every start:

> W0202 14:52:17.121173       1 builder.go:207] unable to get owner reference (falling back to namespace): replicasets.apps "vsphere-problem-detector-operator-65f56d5b76" is forbidden: User "system:serviceaccount:openshift-cluster-storage-operator:vsphere-problem-detector-operator" cannot get resource "replicasets" in API group "apps" in the namespace "openshift-cluster-storage-operator"

This PR adds replicasets to the vsphere role to address this issue.