### PR TITLE
Add service account names to credentials request manifest

### DIFF
--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -8,6 +8,9 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  serviceAccountNames:
+  - aws-ebs-csi-driver-operator
+  - aws-ebs-csi-driver-controller-sa
   secretRef:
     name: ebs-cloud-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
For a new way of managing OpenShift credentials on AWS to work, using Security
Token Service, we need external tooling to know the service account names from
the Credentials Request manifest so that it can create IAM Roles that can be
assumed only by those specific service accounts.

Managing credentials using STS ref: https://github.com/openshift/cloud-credential-operator/blob/master/docs/sts.md
Tooling design ref: https://issues.redhat.com/browse/CCO-60

/cc @joelddiaz 