### PR TITLE
Propagate log level to GCE and Cinder CSI driver operators

### DIFF
--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - args:
         - start
+        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - args:
         - start
+        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -1169,6 +1169,7 @@ spec:
       containers:
       - args:
         - start
+        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -2263,6 +2264,7 @@ spec:
       containers:
       - args:
         - start
+        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}


### PR DESCRIPTION
Looks like oversight, GCE PD and Cinder CSI driver operators did not get logLevel parameter.

@bertinatto, PTAL