### PR TITLE
Bug 1948721: IBM Cloud manifest profile patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+_output/
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/deps-gomod.mk \
 	targets/openshift/images.mk \
 	targets/openshift/bindata.mk \
+	targets/openshift/operator/profile-manifests.mk \
 )
 
 # Run core verification and all self contained tests.
@@ -35,6 +36,13 @@ $(call build-image,cluster-storage-operator,$(IMAGE_REGISTRY)/ocp/4.6:cluster-st
 # $4 - pkg
 # $5 - output
 $(call add-bindata,generated,./assets/...,assets,generated,pkg/generated/bindata.go)
+
+# add targets to manage profile patches
+# $0 - macro name
+# $1 - target name
+# $2 - patches directory
+# $3 - manifests directory
+$(call add-profile-manifests,manifests,./profile-patches,./manifests)
 
 clean:
 	$(RM) cluster-storage-operator

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e // indirect
 	github.com/openshift/api v0.0.0-20210412212256-79bd8cfbbd59
-	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
+	github.com/openshift/build-machinery-go v0.0.0-20210413112106-60cf6ea633f9
 	github.com/openshift/client-go v0.0.0-20210409155308-a8e62c60e930
 	github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2
 	github.com/prometheus-operator/prometheus-operator v0.44.1

--- a/go.sum
+++ b/go.sum
@@ -902,6 +902,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab h1:lB
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359 h1:ehSDsWQiUVzJZrSEXMC7ceV9JIPEyTYqrpqu3m4Wa08=
 github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210413112106-60cf6ea633f9 h1:wRt0Or5hSkh/GPO4Lztq+t7MNVVrWAlj8ZdlVifQQ9M=
+github.com/openshift/build-machinery-go v0.0.0-20210413112106-60cf6ea633f9/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49 h1:7NmjUkJtGHpMTE/n8ia6itbCdZ7eYuTCXKc/zsA7OSM=
 github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49/go.mod h1:9/jG4I6sh+5QublJpZZ4Zs/P4/QCXMsQQ/K/058bSB8=
 github.com/openshift/client-go v0.0.0-20210331195552-cf6c2669e01f/go.mod h1:hHaRJ6vp2MRd/CpuZ1oJkqnMGy5eEnoAkQmKPZKcUPI=

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -1,0 +1,114 @@
+# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+  name: cluster-storage-operator
+  namespace: openshift-cluster-storage-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-storage-operator
+  template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: cluster-storage-operator
+    spec:
+      containers:
+      - command:
+        - cluster-storage-operator
+        - start
+        env:
+        - name: OPERATOR_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: OPERAND_IMAGE_VERSION
+          value: 0.0.1-snapshot
+        - name: AWS_EBS_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-aws-ebs-csi-driver-operator:latest
+        - name: AWS_EBS_DRIVER_IMAGE
+          value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+        - name: GCP_PD_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-gcp-pd-csi-driver-operator:latest
+        - name: GCP_PD_DRIVER_IMAGE
+          value: quay.io/openshift/origin-gcp-pd-csi-driver:latest
+        - name: OPENSTACK_CINDER_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-openstack-cinder-csi-driver-operator:latest
+        - name: OPENSTACK_CINDER_DRIVER_IMAGE
+          value: quay.io/openshift/origin-openstack-cinder-csi-driver:latest
+        - name: OVIRT_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-ovirt-csi-driver-operator:latest
+        - name: OVIRT_DRIVER_IMAGE
+          value: quay.io/openshift/origin-ovirt-csi-driver:latest
+        - name: MANILA_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-csi-driver-manila-operator:latest
+        - name: MANILA_DRIVER_IMAGE
+          value: quay.io/openshift/origin-csi-driver-manila:latest
+        - name: MANILA_NFS_DRIVER_IMAGE
+          value: quay.io/openshift/origin-csi-driver-nfs:latest
+        - name: PROVISIONER_IMAGE
+          value: quay.io/openshift/origin-csi-external-provisioner:latest
+        - name: ATTACHER_IMAGE
+          value: quay.io/openshift/origin-csi-external-attacher:latest
+        - name: RESIZER_IMAGE
+          value: quay.io/openshift/origin-csi-external-resizer:latest
+        - name: SNAPSHOTTER_IMAGE
+          value: quay.io/openshift/origin-csi-external-snapshotter:latest
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: quay.io/openshift/origin-csi-node-driver-registrar:latest
+        - name: LIVENESS_PROBE_IMAGE
+          value: quay.io/openshift/origin-csi-livenessprobe:latest
+        - name: VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-vsphere-problem-detector:latest
+        - name: AZURE_DISK_DRIVER_OPERATOR_IMAGE
+          value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver-operator
+        - name: AZURE_DISK_DRIVER_IMAGE
+          value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
+        - name: VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE
+          value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-operator
+        - name: VMWARE_VSPHERE_DRIVER_IMAGE
+          value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver
+        - name: VMWARE_VSPHERE_SYNCER_IMAGE
+          value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-syncer
+        image: quay.io/openshift/origin-cluster-storage-operator:latest
+        imagePullPolicy: IfNotPresent
+        name: cluster-storage-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+        resources:
+          requests:
+            cpu: 10m
+            memory: 20Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/secrets/serving-cert
+          name: cluster-storage-operator-serving-cert
+      priorityClassName: system-cluster-critical
+      securityContext:
+        fsGroup: 10400
+        runAsGroup: 10400
+        runAsUser: 10400
+      serviceAccountName: cluster-storage-operator
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      volumes:
+      - name: cluster-storage-operator-serving-cert
+        secret:
+          optional: true
+          secretName: cluster-storage-operator-serving-cert

--- a/profile-patches/ibm-cloud-managed/10_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/10_deployment.yaml-patch
@@ -1,0 +1,6 @@
+- op: replace
+  path: /metadata/annotations
+  value:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/vendor/github.com/openshift/build-machinery-go/Makefile
+++ b/vendor/github.com/openshift/build-machinery-go/Makefile
@@ -19,7 +19,7 @@ define update-makefile-log
 mkdir -p "$(3)"
 set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
    sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' | \
-   sed -E 's~/.*/(github.com/openshift/build-machinery-go/.*)~/\1~g' | \
+   sed -E 's~/[^ ]*/(github.com/openshift/build-machinery-go/[^ ]*)~/\1~g' | \
    sed '/\/tmp\/tmp./d' | \
    sed '/git checkout -b/d' | \
    sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \

--- a/vendor/github.com/openshift/build-machinery-go/README.md
+++ b/vendor/github.com/openshift/build-machinery-go/README.md
@@ -40,5 +40,5 @@ Extends [#Default]().
 ### Updating generated files
 We track the log output from the makefile tests to make sure any change is visible and can be audited. Unfortunately due to subtle linux tooling differences in distributions and versions, `make update` may not get you the exact output as the CI. To avoid it, just run the command in the same container as CI:   
 ```
-podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.svc.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
+podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
 ```

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
@@ -6,6 +6,7 @@ self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 # $3 - output file
 define patch-manifest-yq
 	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
+	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
 
 endef
 
@@ -15,6 +16,7 @@ endef
 # $3 - output file
 define patch-manifest-yaml-patch
 	$(YAML_PATCH) -o '$(1)' < '$(2)' > '$(3)'
+	sed -i '$(3)' -e '1s/^/# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***\n/'
 
 endef
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
+# github.com/openshift/build-machinery-go v0.0.0-20210413112106-60cf6ea633f9
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Bumps build-machinery-go to latest
Adds patch specific to ibm-cloud-managed profile that removes node selector for operator deployment
`make verify` verifies that the generated manifest is up to date
`make update` updates the manifest by applying the ibm-cloud-managed patch to the original deployment manifest