### PR TITLE
Remove "vmware" prefix from CSI operator and driver

### DIFF
--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -101,10 +101,10 @@ spec:
             value: quay.io/openshift/origin-kube-rbac-proxy:latest
           - name: VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE
             # TODO: replace with quay.io when the image is mirrored
-            value: registry.ci.openshift.org/origin/4.8:vmware-vsphere-csi-driver-operator
+            value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-operator
           - name: VMWARE_VSPHERE_DRIVER_IMAGE
             # TODO: replace with quay.io when the image is mirrored
-            value: registry.ci.openshift.org/origin/4.8:vmware-vsphere-csi-driver
+            value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver
           - name: VMWARE_VSPHERE_SYNCER_IMAGE
             # TODO: replace with quay.io value
             value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-syncer

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -81,11 +81,11 @@ spec:
   - name: vmware-vsphere-csi-driver-operator
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/origin/4.8:vmware-vsphere-csi-driver-operator
+      name: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-operator
   - name: vmware-vsphere-csi-driver
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/origin/4.8:vmware-vsphere-csi-driver
+      name: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver
   - name: azure-disk-csi-driver-operator
     from:
       kind: DockerImage


### PR DESCRIPTION
This is the third step described here: https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#removing-or-renaming-an-image-from-an-openshift-release-image

CC @openshift/storage
