### PR TITLE
Add management workload annotations

### DIFF
--- a/assets/csidriveroperators/aws-ebs/09_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/09_deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: aws-ebs-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: gcp-pd-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -13,6 +13,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: manila-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: openstack-cinder-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/ovirt/07_deployment.yaml
+++ b/assets/csidriveroperators/ovirt/07_deployment.yaml
@@ -13,6 +13,8 @@ spec:
       name: ovirt-csi-driver-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ovirt-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: vmware-vsphere-csi-driver-operator
     spec:

--- a/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
+++ b/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-storage-operator

--- a/manifests/02_csi_driver_operators_namespace.yaml
+++ b/manifests/02_csi_driver_operators_namespace.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -14,6 +14,8 @@ spec:
       name: cluster-storage-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
     spec:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -610,6 +610,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: aws-ebs-csi-driver-operator
     spec:
@@ -1131,6 +1133,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: gcp-pd-csi-driver-operator
     spec:
@@ -1645,6 +1649,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: manila-csi-driver-operator
     spec:
@@ -2195,6 +2201,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: openstack-cinder-csi-driver-operator
     spec:
@@ -2715,6 +2723,8 @@ spec:
       name: ovirt-csi-driver-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ovirt-csi-driver-operator
     spec:
@@ -3323,6 +3333,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: vmware-vsphere-csi-driver-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>