### PR TITLE
Pass KUBE_RBAC_PROXY_IMAGE to CSI driver operators

### DIFF
--- a/assets/csidriveroperators/aws-ebs/09_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/09_deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/assets/csidriveroperators/azure-disk/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/08_deployment.yaml
@@ -32,6 +32,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -33,6 +33,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/assets/csidriveroperators/ovirt/07_deployment.yaml
+++ b/assets/csidriveroperators/ovirt/07_deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: ${NODE_DRIVER_REGISTRAR_IMAGE}
             - name: LIVENESS_PROBE_IMAGE
               value: ${LIVENESS_PROBE_IMAGE}
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: ${KUBE_RBAC_PROXY_IMAGE}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -101,6 +101,8 @@ spec:
           - name: AZURE_DISK_DRIVER_IMAGE
             # TODO: replace with quay.io when the image is mirrored
             value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+          - name: KUBE_RBAC_PROXY_IMAGE
+            value: quay.io/openshift/origin-kube-rbac-proxy:latest
           resources:
             requests:
               cpu: 10m

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -94,3 +94,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:latest

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -639,6 +639,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -1153,6 +1155,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -1674,6 +1678,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2190,6 +2196,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -2738,6 +2746,8 @@ spec:
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
         - name: LIVENESS_PROBE_IMAGE
           value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -3330,6 +3340,8 @@ spec:
               value: ${NODE_DRIVER_REGISTRAR_IMAGE}
             - name: LIVENESS_PROBE_IMAGE
               value: ${LIVENESS_PROBE_IMAGE}
+            - name: KUBE_RBAC_PROXY_IMAGE
+              value: ${KUBE_RBAC_PROXY_IMAGE}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/pkg/operator/csidriveroperator/util.go
+++ b/pkg/operator/csidriveroperator/util.go
@@ -19,6 +19,7 @@ const (
 	envSnapshotterImage         = "SNAPSHOTTER_IMAGE"
 	envNodeDriverRegistrarImage = "NODE_DRIVER_REGISTRAR_IMAGE"
 	envLivenessProbeImage       = "LIVENESS_PROBE_IMAGE"
+	envKubeRBACProxyImage       = "KUBE_RBAC_PROXY_IMAGE"
 )
 
 var (
@@ -29,6 +30,7 @@ var (
 		"${SNAPSHOTTER_IMAGE}", os.Getenv(envSnapshotterImage),
 		"${NODE_DRIVER_REGISTRAR_IMAGE}", os.Getenv(envNodeDriverRegistrarImage),
 		"${LIVENESS_PROBE_IMAGE}", os.Getenv(envLivenessProbeImage),
+		"${KUBE_RBAC_PROXY_IMAGE}", os.Getenv(envKubeRBACProxyImage),
 	)
 )
 


### PR DESCRIPTION
So they can use the right kube-rbac-proxy image in their Pods.

cc @openshift/storage 