### PR TITLE
Degrade the cluster when an unsupported CSI driver is already installed

### DIFF
--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -5,6 +5,8 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestShouldRunController(t *testing.T) {
@@ -12,85 +14,127 @@ func TestShouldRunController(t *testing.T) {
 		name        string
 		platform    v1.PlatformType
 		featureGate *v1.FeatureGate
+		csiDriver   *storagev1.CSIDriver
 		config      csioperatorclient.CSIOperatorConfig
 		expectRun   bool
+		expectError bool
 	}{
 		{
 			"GA CSI driver on matching platform",
 			v1.AWSPlatformType,
 			featureSet(""),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "ebs.csi.aws.com",
 				Platform:           v1.AWSPlatformType,
 				RequireFeatureGate: "",
 			},
 			true,
+			false,
 		},
 		{
 			"GA CSI driver on non-matching platform",
 			v1.GCPPlatformType,
 			featureSet(""),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "ebs.csi.aws.com",
 				Platform:           v1.AWSPlatformType,
 				RequireFeatureGate: "",
 			},
+			false,
 			false,
 		},
 		{
 			"tech preview driver on non-matching platform",
 			v1.VSpherePlatformType,
 			featureSet("TechPreviewNoUpgrade"),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "vsphere",
 				Platform:           v1.AWSPlatformType,
 				RequireFeatureGate: "CSIDriverVSphere",
 			},
 			false,
+			false,
 		},
 		{
 			"tech preview driver with enabled TechPreviewNoUpgrade FeatureSet",
 			v1.VSpherePlatformType,
 			featureSet("TechPreviewNoUpgrade"),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "vsphere",
 				Platform:           v1.VSpherePlatformType,
 				RequireFeatureGate: "CSIDriverVSphere",
 			},
 			true,
+			false,
 		},
 		{
 			"tech preview driver with disabled TechPreviewNoUpgrade FeatureSet",
 			v1.VSpherePlatformType,
 			featureSet(""),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "vsphere",
 				Platform:           v1.VSpherePlatformType,
 				RequireFeatureGate: "CSIDriverVSphere",
 			},
+			false,
 			false,
 		},
 		{
 			"tech preview driver with correct CustomNoUpgrade FeatureSet",
 			v1.VSpherePlatformType,
 			customSet("foo", "bar", "baz", "CSIDriverVSphere"),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "vsphere",
 				Platform:           v1.VSpherePlatformType,
 				RequireFeatureGate: "CSIDriverVSphere",
 			},
 			true,
+			false,
 		},
 		{
 			"tech preview driver with wrong CustomNoUpgrade FeatureSet",
 			v1.VSpherePlatformType,
 			customSet("foo", "bar", "baz"),
+			nil,
 			csioperatorclient.CSIOperatorConfig{
 				CSIDriverName:      "vsphere",
 				Platform:           v1.VSpherePlatformType,
 				RequireFeatureGate: "CSIDriverVSphere",
 			},
 			false,
+			false,
+		},
+		{
+			"tech preview driver with existing OpenShift CSIDriver",
+			v1.VSpherePlatformType,
+			customSet("CSIDriverVSphere"),
+			csiDriver("vsphere", map[string]string{annOpenShiftManaged: "true"}),
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "vsphere",
+				Platform:           v1.VSpherePlatformType,
+				RequireFeatureGate: "CSIDriverVSphere",
+			},
+			true,
+			false,
+		},
+		{
+			"tech preview driver with existing community CSIDriver",
+			v1.VSpherePlatformType,
+			customSet("CSIDriverVSphere"),
+			csiDriver("vsphere", nil),
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "vsphere",
+				Platform:           v1.VSpherePlatformType,
+				RequireFeatureGate: "CSIDriverVSphere",
+			},
+			false,
+			true,
 		},
 	}
 
@@ -104,11 +148,13 @@ func TestShouldRunController(t *testing.T) {
 					},
 				},
 			}
-			fg := test.featureGate
-			cfg := test.config
-			res := shouldRunController(cfg, infra, fg)
+			res, err := shouldRunController(test.config, infra, test.featureGate, test.csiDriver)
 			if res != test.expectRun {
 				t.Errorf("Expected run %t, got %t", test.expectRun, res)
+			}
+			gotError := err != nil
+			if gotError != test.expectError {
+				t.Errorf("Expected error %t, got %t: %s", test.expectError, res, err)
 			}
 		})
 	}
@@ -134,5 +180,15 @@ func customSet(gates ...string) *v1.FeatureGate {
 				},
 			},
 		},
+	}
+}
+
+func csiDriver(csiDriverName string, annotations map[string]string) *storagev1.CSIDriver {
+	return &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        csiDriverName,
+			Annotations: annotations,
+		},
+		Spec: storagev1.CSIDriverSpec{},
 	}
 }


### PR DESCRIPTION
When opt-in CSI driver should be installed and the driver is already installed, but it's not the OpenShift one, Degrade the whole cluster and wait until user removes the other (community) CSI driver.

This affects only CSI drivers that are installed after TechPreviewNoUpgrade FeatureSet is set.

We distinguish "our" CSI driver by presence of annotation "csi.openshift.io/managed".

Passing CSIDriver to `shouldRunController` to simplify unit tests.

@openshift/storage 
