### PR TITLE
Add TokenReview permissions to newly introduced operators

### DIFF
--- a/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
@@ -260,3 +260,10 @@ rules:
   - get
   - list
   - watch
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"

--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -284,3 +284,10 @@ rules:
   - watch
   - update
   - delete
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -1075,6 +1075,13 @@ rules:
   - get
   - list
   - watch
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"
 `)
 
 func csidriveroperatorsAzureDisk06_clusterroleYamlBytes() ([]byte, error) {
@@ -3797,6 +3804,13 @@ rules:
   - watch
   - update
   - delete
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"
 `)
 
 func csidriveroperatorsVsphere06_clusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Azure Disk and vSphere CSI driver operators need permissions to create TokenReviews to authenticate Prometheus when it's collecting metrics.

@openshift/storage 