### PR TITLE
Bug 1948505: Add missing RBAC rules for vSphere

### DIFF
--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -19,6 +19,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -252,6 +255,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -3549,6 +3549,9 @@ rules:
   - get
   - list
   - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -3782,6 +3785,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - proxies
   verbs:
   - get
   - list


### PR DESCRIPTION
The operator needs to watch the `proxies` resource and update the `clustercsidriver`'s spec. This patch adds the missing RBAC rules that allow those actions.

Similar PRs for other operators:

https://github.com/openshift/cluster-storage-operator/pull/121
https://github.com/openshift/cluster-storage-operator/pull/127

CC @openshift/storage
