### PR TITLE
Bug 1949554: Pass KUBE_RBAC_PROXY to vSphere CSI driver operator

### DIFF
--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -36,6 +36,8 @@ spec:
           value: ${LIVENESS_PROBE_IMAGE}
         - name: VMWARE_VSPHERE_SYNCER_IMAGE
           value: ${VMWARE_VSPHERE_SYNCER_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -3905,6 +3905,8 @@ spec:
           value: ${LIVENESS_PROBE_IMAGE}
         - name: VMWARE_VSPHERE_SYNCER_IMAGE
           value: ${VMWARE_VSPHERE_SYNCER_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
To be able to run kube-rbac-proxy pods to collect metrics via HTTPS.