### PR TITLE
Bug 1949357: Add missing RBAC rules to Manila operator

### DIFF
--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -265,3 +265,20 @@ rules:
   verbs:
   - get
   - create
+# Allow the operator to create Service in the driver namespace
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - '*'
+# Grant these permissions in the driver namespace to Prometheus
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - endpoints
+  verbs:
+  - 'get'
+  - 'list'
+  - 'watch'

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -2124,6 +2124,23 @@ rules:
   verbs:
   - get
   - create
+# Allow the operator to create Service in the driver namespace
+- apiGroups:
+  - ''
+  resources:
+  - services
+  verbs:
+  - '*'
+# Grant these permissions in the driver namespace to Prometheus
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - endpoints
+  verbs:
+  - 'get'
+  - 'list'
+  - 'watch'
 `)
 
 func csidriveroperatorsManila05_clusterroleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
To be able to create Service and grand permission to Prometheus to list objects to collect metrics from them.

cc @openshift/storage 