### PR TITLE
Rename workload annotations

### DIFF
--- a/assets/csidriveroperators/aws-ebs/09_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/09_deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: aws-ebs-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/azure-disk/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/08_deployment.yaml
@@ -11,6 +11,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: azure-disk-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: gcp-pd-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: manila-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: openstack-cinder-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/ovirt/07_deployment.yaml
+++ b/assets/csidriveroperators/ovirt/07_deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ovirt-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: vmware-vsphere-csi-driver-operator
     spec:

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
     spec:

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
     spec:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -618,7 +618,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: aws-ebs-csi-driver-operator
     spec:
@@ -1143,6 +1143,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: azure-disk-csi-driver-operator
     spec:
@@ -1667,7 +1669,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: gcp-pd-csi-driver-operator
     spec:
@@ -2203,7 +2205,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: manila-csi-driver-operator
     spec:
@@ -2757,7 +2759,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: openstack-cinder-csi-driver-operator
     spec:
@@ -3281,7 +3283,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ovirt-csi-driver-operator
     spec:
@@ -3904,7 +3906,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: vmware-vsphere-csi-driver-operator
     spec:


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged