### PR TITLE
Bug 1943719: Add alert about vsphere-problem-detector unable to connect

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -10,6 +10,8 @@ spec:
     - name: vsphere-problem-detector.rules
       rules:
       - alert: VSphereOpenshiftNodeHealthFail
+        # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr:  min_over_time(vsphere_node_check_errors[5m]) == 1
         for: 10m
         labels:
@@ -17,9 +19,27 @@ spec:
         annotations:
           message: "VSphere health check {{ $labels.check }} is failing on {{ $labels.node }}."
       - alert: VSphereOpenshiftClusterHealthFail
+        # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr: min_over_time(vsphere_cluster_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning
         annotations:
           message: "VSphere cluster health checks are failing with {{ $labels.check }}"
+      - alert: VSphereOpenshiftConnectionFailure
+        # Using min_over_time to make sure the metric is `1` for whole 15 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
+        expr: min_over_time(vsphere_sync_errors[15m]) == 1
+        for: 60m
+        labels:
+          severity: warning
+        annotations:
+          summary: "vsphere-problem-detector is unable to connect to vSphere vCenter."
+          description: |
+            vsphere-problem-detector cannot access vCenter. As consequence, other OCP components,
+            such as storage or machine API, may not be able to access vCenter too and provide
+            their services. Detailed error message can be found in Available condition of
+            ClusterOperator "storage", either in console
+            (Administration -> Cluster settings -> Cluster operators tab -> storage) or on
+            command line: oc get clusteroperator storage -o jsonpath='{.status.conditions[?(@.type=="Available")].message}'

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -4520,6 +4520,8 @@ spec:
     - name: vsphere-problem-detector.rules
       rules:
       - alert: VSphereOpenshiftNodeHealthFail
+        # Using min_over_time to make sure the metric is ` + "`" + `1` + "`" + ` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr:  min_over_time(vsphere_node_check_errors[5m]) == 1
         for: 10m
         labels:
@@ -4527,12 +4529,30 @@ spec:
         annotations:
           message: "VSphere health check {{ $labels.check }} is failing on {{ $labels.node }}."
       - alert: VSphereOpenshiftClusterHealthFail
+        # Using min_over_time to make sure the metric is ` + "`" + `1` + "`" + ` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr: min_over_time(vsphere_cluster_check_errors[5m]) == 1
         for: 10m
         labels:
           severity: warning
         annotations:
           message: "VSphere cluster health checks are failing with {{ $labels.check }}"
+      - alert: VSphereOpenshiftConnectionFailure
+        # Using min_over_time to make sure the metric is ` + "`" + `1` + "`" + ` for whole 15 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
+        expr: min_over_time(vsphere_sync_errors[15m]) == 1
+        for: 60m
+        labels:
+          severity: warning
+        annotations:
+          summary: "vsphere-problem-detector is unable to connect to vSphere vCenter."
+          description: |
+            vsphere-problem-detector cannot access vCenter. As consequence, other OCP components,
+            such as storage or machine API, may not be able to access vCenter too and provide
+            their services. Detailed error message can be found in Available condition of
+            ClusterOperator "storage", either in console
+            (Administration -> Cluster settings -> Cluster operators tab -> storage) or on
+            command line: oc get clusteroperator storage -o jsonpath='{.status.conditions[?(@.type=="Available")].message}'
 `)
 
 func vsphere_problem_detector12_prometheusrulesYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Following https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md, using Warning severity + long `Description` + 60 minutes for the alert to fire. Not sure if alerts should be that talkative.

 This PR depends on https://github.com/openshift/vsphere-problem-detector/pull/39 to provide the metric to alert on.

@openshift/storage 