### PR TITLE
Bug 1961120: added permissions to service monitoring

### DIFF
--- a/assets/csidriveroperators/aws-ebs/03_role.yaml
+++ b/assets/csidriveroperators/aws-ebs/03_role.yaml
@@ -38,3 +38,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/azure-disk/04_role.yaml
+++ b/assets/csidriveroperators/azure-disk/04_role.yaml
@@ -38,3 +38,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/gcp-pd/03_role.yaml
+++ b/assets/csidriveroperators/gcp-pd/03_role.yaml
@@ -38,3 +38,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -265,6 +265,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 # Allow the operator to create Service in the driver namespace
 - apiGroups:
   - ''

--- a/assets/csidriveroperators/openstack-cinder/03_role.yaml
+++ b/assets/csidriveroperators/openstack-cinder/03_role.yaml
@@ -38,3 +38,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/ovirt/03_role.yaml
+++ b/assets/csidriveroperators/ovirt/03_role.yaml
@@ -39,3 +39,6 @@ rules:
     verbs:
       - get
       - create
+      - update
+      - patch
+      - delete

--- a/assets/csidriveroperators/vsphere/04_role.yaml
+++ b/assets/csidriveroperators/vsphere/04_role.yaml
@@ -38,3 +38,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/assets/vsphere_problem_detector/02_role.yaml
+++ b/assets/vsphere_problem_detector/02_role.yaml
@@ -36,3 +36,6 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -180,6 +180,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func csidriveroperatorsAwsEbs03_roleYamlBytes() ([]byte, error) {
@@ -768,6 +771,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func csidriveroperatorsAzureDisk04_roleYamlBytes() ([]byte, error) {
@@ -1294,6 +1300,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func csidriveroperatorsGcpPd03_roleYamlBytes() ([]byte, error) {
@@ -2126,6 +2135,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 # Allow the operator to create Service in the driver namespace
 - apiGroups:
   - ''
@@ -2379,6 +2391,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func csidriveroperatorsOpenstackCinder03_roleYamlBytes() ([]byte, error) {
@@ -2913,6 +2928,9 @@ rules:
     verbs:
       - get
       - create
+      - update
+      - patch
+      - delete
 `)
 
 func csidriveroperatorsOvirt03_roleYamlBytes() ([]byte, error) {
@@ -3502,6 +3520,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func csidriveroperatorsVsphere04_roleYamlBytes() ([]byte, error) {
@@ -4200,6 +4221,9 @@ rules:
   verbs:
   - get
   - create
+  - update
+  - patch
+  - delete
 `)
 
 func vsphere_problem_detector02_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This PR added permissions to operators service monitoring, allowing cluster version upgrade.

Currently the operators has `create` permission. When upgrading the cluster, it needs permission to `update` the service role.