### PR TITLE
Bug 1961538: manifests: remove namespace from cluster-storage-operator-role binding

### DIFF
--- a/manifests/08_operator_rbac.yaml
+++ b/manifests/08_operator_rbac.yaml
@@ -2,7 +2,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-storage-operator-role
-  namespace: openshift-cluster-storage-operator
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
ClusterRoleBindings are non-namespaced objects, so they should not set namespace in the manifest. This makes CVO hotloop on this manifest, attempting to reconcile it