### PR TITLE
Bug 1947402: Add permissions poddisruptionbudgets in AWS CSI operator'

### DIFF
--- a/assets/csidriveroperators/aws-ebs/03_role.yaml
+++ b/assets/csidriveroperators/aws-ebs/03_role.yaml
@@ -32,6 +32,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -174,6 +174,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
This is required by github.com/openshift/aws-ebs-csi-driver-operator/pull/122.

CC @openshift/storage
