### PR TITLE
Bug 1948090: Remove CSIDriverOperatorDeploymentAvailable condition when deploying CSI operator

### DIFF
--- a/pkg/operator/csidriveroperator/util.go
+++ b/pkg/operator/csidriveroperator/util.go
@@ -6,10 +6,15 @@ import (
 	"os"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -62,4 +67,43 @@ func reportUpdateEvent(recorder events.Recorder, obj runtime.Object, originalErr
 	default:
 		recorder.Eventf(fmt.Sprintf("%sUpdated", gvk.Kind), "Updated %s:\n%s", resourcehelper.FormatResourceForCLIWithNamespace(obj), strings.Join(details, "\n"))
 	}
+}
+
+func checkDeploymentHealth(ctx context.Context, c appsclientv1.DeploymentsGetter, d *appsv1.Deployment) error {
+	d, err := c.Deployments(d.Namespace).Get(ctx, d.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	name := fmt.Sprintf("%s/%s", d.Namespace, d.Name)
+	progressing := getDeploymentCondition(appsv1.DeploymentProgressing, &d.Status)
+	if progressing != nil && progressing.Status == corev1.ConditionFalse && progressing.Reason == "ProgressDeadlineExceeded" {
+		return fmt.Errorf("deployment %s is %s=%s: %s: %s", name, progressing.Type, progressing.Status, progressing.Reason, progressing.Message)
+	}
+
+	replicaFailure := getDeploymentCondition(appsv1.DeploymentReplicaFailure, &d.Status)
+	if replicaFailure != nil && replicaFailure.Status == corev1.ConditionTrue {
+		return fmt.Errorf("deployment %s has some pods failing; unavailable replicas=%d", name, d.Status.UnavailableReplicas)
+	}
+
+	available := getDeploymentCondition(appsv1.DeploymentAvailable, &d.Status)
+	if available != nil && available.Status == corev1.ConditionFalse && progressing != nil && progressing.Status == corev1.ConditionFalse {
+		return fmt.Errorf("deployment %s is not available and not progressing; updated replicas=%d of %d, available replicas=%d of %d",
+			name,
+			d.Status.UpdatedReplicas,
+			d.Status.Replicas,
+			d.Status.AvailableReplicas,
+			d.Status.Replicas)
+	}
+
+	return nil
+}
+
+func getDeploymentCondition(condType appsv1.DeploymentConditionType, status *appsv1.DeploymentStatus) *appsv1.DeploymentCondition {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == condType {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
 }

--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_deployment.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_deployment.go
@@ -27,6 +27,7 @@ const (
 	deploymentControllerName            = "VSphereProblemDetectorDeploymentController"
 )
 
+// TODO: move to DeploymentController form library-go instead
 type VSphereProblemDetectorDeploymentController struct {
 	operatorClient v1helpers.OperatorClient
 	kubeClient     kubernetes.Interface


### PR DESCRIPTION
Currently, we deploy only one replica of the CSI operator Deployment. This apparently leads to CSO going unavailable when draining the node where a CSI operator is running on.

A reasonable way to fix this issue would be to run multiple replicas of the CSI operator, however, we chose to remove the _CSIDriverOperatorDeploymentAvailable_ condition instead. This condition was was being set to _False_ when draining the node where the CSI operator was running on, cascading the status up to the top _Available_ condition (through the unioning done in the CR controller in CSO).

From now on, the unioning that determines the top _Available_ state relies on the other _Available_ conditions reported by other controllers and by the CSI operator.

In addition to that, I introduced a health check for the CSI operator Deployment to make sure we go _Degraded_ if for some reason the CSI operator is not deployed successfully.
