### PR TITLE
WIP: Debug CSI migration

### DIFF
--- a/assets/csidriveroperators/aws-ebs/10_cr.yaml
+++ b/assets/csidriveroperators/aws-ebs/10_cr.yaml
@@ -3,6 +3,6 @@ kind: "ClusterCSIDriver"
 metadata:
   name: "ebs.csi.aws.com"
 spec:
-  logLevel: Normal
+  logLevel: Trace
   managementState: Managed
-  operatorLogLevel: Normal
+  operatorLogLevel: Trace

--- a/manifests/06_operator_cr.yaml
+++ b/manifests/06_operator_cr.yaml
@@ -9,5 +9,5 @@ metadata:
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
-  logLevel: Normal
-  operatorLogLevel: Normal
+  logLevel: Trace
+  operatorLogLevel: Trace


### PR DESCRIPTION
Get more logs from the CSI driver to debug corrupted ext4 when CSI migration is used.