### PR TITLE
Add service account names to gcp credentials request manifest

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -7,6 +7,9 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
+  serviceAccountNames:
+  - gcp-pd-csi-driver-operator
+  - gcp-pd-csi-driver-controller-sa
   secretRef:
     name: gcp-pd-cloud-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
For enabling short-lived credentials in gcp cluster using workload
identity (similar to AWS STS), we need ccoctl tool to know the
kubernetes service account names from the credentials request
manifest so that it can create gcp service accounts that can be
impersonated only by specific kubernetes service accounts.

ref: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity