### PR TITLE
Add permissions to get, list and watch pods for ovirt-csi-operator

### DIFF
--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -73,6 +73,7 @@ rules:
   - ''
   resources:
   - secrets
+  - pods
   verbs:
   - get
   - list


### PR DESCRIPTION
We need to add permissions to get, list and watch pods for PR https://github.com/openshift/ovirt-csi-driver-operator/pull/64/files#diff-be967bcd761c2fada6b517801fd5972ba5ae149ad579c6a31d9e2d158ac0d961R21-R23