### PR TITLE
Remove ibm-cloud-managed annotation from operator deployment

### DIFF
--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cluster-storage-operator
   namespace: openshift-cluster-storage-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:


### PR DESCRIPTION
For ibm-cloud-managed we are already creating an alternate deployment manifest without a master node selector. This removes the annotation from the main deployment manifest so the CVO only uses one or the other.