### PR TITLE
Support external control plane topology

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -41,6 +41,8 @@ type CSIOperatorConfig struct {
 	OLMOptions *OLMOptions
 	// Run the CSI driver operator only when given FeatureGate is enabled
 	RequireFeatureGate string
+	// Schedule CSI driver operator on workers when control plane is externalized
+	ScheduleOnWorkers bool
 }
 
 // OLMOptions contains information that is necessary to remove old CSI driver

--- a/pkg/operator/csidriveroperator/deploymentcontroller.go
+++ b/pkg/operator/csidriveroperator/deploymentcontroller.go
@@ -114,6 +114,9 @@ func (c *CSIDriverOperatorDeploymentController) Sync(ctx context.Context, syncCt
 	if err != nil {
 		return fmt.Errorf("failed to inject proxy data into deployment: %w", err)
 	}
+	if c.csiOperatorConfig.ScheduleOnWorkers {
+		requiredCopy.Spec.Template.Spec.NodeSelector = map[string]string{}
+	}
 
 	_, err = csoutils.CreateDeployment(ctx, csoutils.DeploymentOptions{
 		Required:       requiredCopy,

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -150,6 +150,7 @@ func (c *CSIDriverStarterController) sync(ctx context.Context, syncCtx factory.S
 			if !shouldRun {
 				continue
 			}
+			ctrl.operatorConfig.ScheduleOnWorkers = shouldScheduleOnWorkers(infrastructure)
 			relatedObjects = append(relatedObjects, configv1.ObjectReference{
 				Group:    operatorapi.GroupName,
 				Resource: "clustercsidrivers",
@@ -294,4 +295,8 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 	}
 
 	return true
+}
+
+func shouldScheduleOnWorkers(infra *configv1.Infrastructure) bool {
+	return infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
 }


### PR DESCRIPTION
If running on a cluster with control plane topology of type 'External' (as in ROKS or Hypershift), CSI operators should not be scheduled to masters. This change sets the node selector to empty if this is the case.