### PR TITLE
Add alert about HW version < 15

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -43,3 +43,20 @@ spec:
             ClusterOperator "storage", either in console
             (Administration -> Cluster settings -> Cluster operators tab -> storage) or on
             command line: oc get clusteroperator storage -o jsonpath='{.status.conditions[?(@.type=="Available")].message}'
+      - alert: CSIWithOldVSphereHWVersion
+        # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
+        # Using ON() to have logical "and" with unrelated labels.
+        expr: |
+          min_over_time(vsphere_node_hw_version_total{hw_version=~"vmx-(11|12|13|14)"}[5m]) > 0
+          and ON()
+          count(cluster_feature_set{name="TechPreviewNoUpgrade"}) > 0
+        for: 60m
+        labels:
+          severity: info
+        annotations:
+          summary: "Detected vSphere VM with HW version lower than 15, which is not supported by the installed vSphere CSI driver."
+          description: |
+            The cluster runs the vSphere CSI driver (it has TechPreviewNoUpgrade features enabled) and the CSI driver does not
+            support vSphere VMs with HW version lower than 15. Please update HW version of all VMs that are part of the cluster
+            to at least HW version 15.


### PR DESCRIPTION
When the CSI driver is installed (i.e. `TechPreviewNoUpgrade` is set), alert when there is a VMs with HW version < 15.

If I understand promql, `ON()` is required to have logical `and` with two unrelated queries.