### PR TITLE
 Bug 1986557: Install CSI drivers on all platforms

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -8,6 +8,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	// AllPlatforms is a special PlatformType that indicates a CSI driver is installable on any cloud provider.
+	// It is only meant to be used by the CSIOperatorConfig, and does not represent a real OpenShift platform type.
+	AllPlatforms configv1.PlatformType = "AllPlatforms"
+)
+
 // CSIOperatorConfig is configuration of a CSI driver operator.
 type CSIOperatorConfig struct {
 	// Name of the CSI driver (such as ebs.csi.aws.com) and at the same time

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -233,7 +233,7 @@ func shouldRunController(cfg csioperatorclient.CSIOperatorConfig, infrastructure
 	if infrastructure.Status.PlatformStatus != nil {
 		platform = infrastructure.Status.PlatformStatus.Type
 	}
-	if cfg.Platform != platform {
+	if cfg.Platform != csioperatorclient.AllPlatforms && cfg.Platform != platform {
 		klog.V(5).Infof("Not starting %s: wrong platform %s", cfg.CSIDriverName, platform)
 		return false, nil
 	}

--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -136,6 +136,32 @@ func TestShouldRunController(t *testing.T) {
 			false,
 			true,
 		},
+		{
+			"GA CSI Driver on any platform",
+			v1.AWSPlatformType,
+			featureSet(""),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "sharedresource",
+				Platform:           csioperatorclient.AllPlatforms,
+				RequireFeatureGate: "",
+			},
+			true,
+			false,
+		},
+		{
+			"custom feature gate CSI Driver on any platform",
+			v1.AWSPlatformType,
+			customSet("foo", "bar", "CSIDriverSharedResource"),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "sharedresource",
+				Platform:           csioperatorclient.AllPlatforms,
+				RequireFeatureGate: "CSIDriverSharedResource",
+			},
+			true,
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Allow platform-agnostic CSI drivers to be installed on all platforms.
This allows CSI drivers that do not depend on a specific cloud provider
to be installed by the cluster storage operator.