### PR TITLE
Bug 1948090: Fix poddisruptionbudget RBAC rule for Manila

### DIFF
--- a/assets/csidriveroperators/manila/03_role.yaml
+++ b/assets/csidriveroperators/manila/03_role.yaml
@@ -31,9 +31,3 @@ rules:
   - statefulsets
   verbs:
   - '*'
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - '*'

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -285,3 +285,9 @@ rules:
   - 'get'
   - 'list'
   - 'watch'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'


### PR DESCRIPTION
The Manila CSI operator creates a PDB in the `openshift-manila-csi-driver` namespace, not in the `openshift-cluster-csi-drivers` one (like the other CSI operators).

I'm moving this to a ClusterRole, but we review anf fix the Role instead. I'll create a BZ for that.

CC @openshift/storage
