### PR TITLE
Bug 1990601: Always run CSI driver controller for Azure Stack Hub

### DIFF
--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -244,6 +244,13 @@ func shouldRunController(cfg csioperatorclient.CSIOperatorConfig, infrastructure
 		return true, nil
 	}
 
+	// For Azure Stack Hub we have to enable the CSI driver because it does not support
+	// in-tree volume plugin for azure disk.
+	if isAzureStackHub(infrastructure.Status.PlatformStatus) {
+		klog.V(5).Infof("Starting %s for Azure Stack Hub", cfg.CSIDriverName)
+		return true, nil
+	}
+
 	if !featureGateEnabled(fg, cfg.RequireFeatureGate) {
 		klog.V(4).Infof("Not starting %s: feature %s is not enabled", cfg.CSIDriverName, cfg.RequireFeatureGate)
 		return false, nil
@@ -299,4 +306,8 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 
 func shouldScheduleOnWorkers(infra *configv1.Infrastructure) bool {
 	return infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
+}
+
+func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
+	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }

--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -160,6 +160,33 @@ func TestShouldRunController(t *testing.T) {
 	}
 }
 
+func TestShouldRunControllerAzureStackHub(t *testing.T) {
+	infra := &v1.Infrastructure{
+		Status: v1.InfrastructureStatus{
+			PlatformStatus: &v1.PlatformStatus{
+				Type: v1.AzurePlatformType,
+				Azure: &v1.AzurePlatformStatus{
+					CloudName: v1.AzureStackCloud,
+				},
+			},
+		},
+	}
+
+	config := csioperatorclient.CSIOperatorConfig{
+		CSIDriverName:      "disk.csi.azure.com",
+		Platform:           v1.AzurePlatformType,
+		RequireFeatureGate: "CSIDriverAzureDisk",
+	}
+
+	res, err := shouldRunController(config, infra, nil, nil)
+	if err != nil {
+		t.Errorf("Unexpected error occurred: %v", err)
+	}
+	if !res {
+		t.Error("Expected to run controller for Azure Stack Hub")
+	}
+}
+
 func featureSet(set v1.FeatureSet) *v1.FeatureGate {
 	return &v1.FeatureGate{
 		Spec: v1.FeatureGateSpec{


### PR DESCRIPTION
Since Azure Stack Hub does not support in-tree volume plugin for azure disk, we have to always enable the CSI driver for this platform.

This commit checks if we use Azure Stack Hub and enables the driver, even if the feature gate may not be set.