### PR TITLE
Bug 1990662: Create namespace for manila on all OpenStack installations

### DIFF
--- a/assets/csidriveroperators/manila/01_namespace.yaml
+++ b/assets/csidriveroperators/manila/01_namespace.yaml
@@ -1,0 +1,10 @@
+# Creating the namespace in cluster-storage-operator to simplify ReplatedObjects
+# composition - cluster-storage-operator needs to know what namespaces to add
+# there.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-manila-csi-driver
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""

--- a/pkg/operator/csidriveroperator/csioperatorclient/manila.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/manila.go
@@ -33,6 +33,7 @@ func GetManilaOperatorConfig(clients *csoclients.Clients, recorder events.Record
 		ConditionPrefix: "Manila",
 		Platform:        v1.OpenStackPlatformType,
 		StaticAssets: []string{
+			"csidriveroperators/manila/01_namespace.yaml",
 			"csidriveroperators/manila/02_sa.yaml",
 			"csidriveroperators/manila/03_role.yaml",
 			"csidriveroperators/manila/04_rolebinding.yaml",

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -31,7 +31,6 @@ const (
 
 const (
 	operatorNamespace   = "openshift-cluster-storage-operator"
-	manilaNamespace     = "openshift-manila-csi-driver"
 	clusterOperatorName = "storage"
 )
 
@@ -57,7 +56,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	relatedObjects := []configv1.ObjectReference{
 		{Resource: "namespaces", Name: operatorNamespace},
 		{Resource: "namespaces", Name: csoclients.CSIOperatorNamespace},
-		{Resource: "namespaces", Name: manilaNamespace},
 		{Group: operatorv1.GroupName, Resource: "storages", Name: operatorclient.GlobalConfigName},
 	}
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(


### PR DESCRIPTION
CSO needs to provide `ClusterOperator.Status.RelatedObjects` with existing objects. `openshift-manila-csi-driver` does not exist on clusters without Manila service and this causes errors.

Therefore make sure the manila namespace exists on all OpenStack installations. It will be added to `RelatedObjects` via `StaticController.RelatedObjects()` only on OpenStack then.

As tradeoff, on OpenStack without Manila service, there will be empty `openshift-manila-csi-driver` namespace. cluster-storage-operator does not talk to OpenStack to discover Manila and adding that would be too complex.