### PR TITLE
Bug 1992857: allow Azure CSI driver operator to read configmaps globally

### DIFF
--- a/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
@@ -42,6 +42,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterroles


### PR DESCRIPTION
To allow syncing "cloud-provider-config" cm from "openshift-config" namespace with "openshift-cluster-csi-drivers", we have to provide the operator the appropriate permissions.