### PR TITLE
Bug 1985391: Add proxy support to cinder CSI

### DIFF
--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: openstack-cinder-csi-driver-operator
   namespace: openshift-cluster-csi-drivers
+  annotations:
+    config.openshift.io/inject-proxy: openstack-cinder-csi-driver-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Adds annotation to inject proxy env vars
to cinder-csi-driver-operator when proxy
is being used.