### PR TITLE
Bug 1992875: Add azure credentials

### DIFF
--- a/assets/csidriveroperators/azure-disk/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/08_deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: ${LIVENESS_PROBE_IMAGE}
         - name: KUBE_RBAC_PROXY_IMAGE
           value: ${KUBE_RBAC_PROXY_IMAGE}
+        - name: CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE
+          value: ${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -1,0 +1,18 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: azure-disk-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor
+  secretRef:
+    name: azure-disk-credentials
+    namespace: openshift-cluster-csi-drivers

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -75,6 +75,8 @@ spec:
           value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver
         - name: VMWARE_VSPHERE_SYNCER_IMAGE
           value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-syncer
+        - name: CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -107,6 +107,8 @@ spec:
           - name: VMWARE_VSPHERE_SYNCER_IMAGE
             # TODO: replace with quay.io value
             value: registry.ci.openshift.org/origin/4.8:vsphere-csi-driver-syncer
+          - name: CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE
+            value: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:latest
           resources:
             requests:
               cpu: 10m

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -102,3 +102,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:latest
+  - name: cluster-cloud-controller-manager-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:latest

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
@@ -11,12 +11,14 @@ const (
 	AzureDiskDriverName             = "disk.csi.azure.com"
 	envAzureDiskDriverOperatorImage = "AZURE_DISK_DRIVER_OPERATOR_IMAGE"
 	envAzureDiskDriverImage         = "AZURE_DISK_DRIVER_IMAGE"
+	envCCMOperatorImage             = "CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE"
 )
 
 func GetAzureDiskCSIOperatorConfig() CSIOperatorConfig {
 	pairs := []string{
 		"${OPERATOR_IMAGE}", os.Getenv(envAzureDiskDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envAzureDiskDriverImage),
+		"${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}", os.Getenv(envCCMOperatorImage),
 	}
 
 	return CSIOperatorConfig{


### PR DESCRIPTION
Add credentials for Azure Disk CSI driver via cloud-credentials-operator.

In addition, pass name of cluster-cloud-controller-manager-operator image to Azure CSI driver operator, so the operator can merge cloud config + the new credentials easily (see #https://github.com/openshift/azure-disk-csi-driver-operator/pull/30).