### PR TITLE
Bug 1999853: ControlPlaneTopology: Fix node selector for CSI driver operator deployment

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -47,8 +47,6 @@ type CSIOperatorConfig struct {
 	OLMOptions *OLMOptions
 	// Run the CSI driver operator only when given FeatureGate is enabled
 	RequireFeatureGate string
-	// Schedule CSI driver operator on workers when control plane is externalized
-	ScheduleOnWorkers bool
 }
 
 // OLMOptions contains information that is necessary to remove old CSI driver

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -150,7 +150,6 @@ func (c *CSIDriverStarterController) sync(ctx context.Context, syncCtx factory.S
 			if !shouldRun {
 				continue
 			}
-			ctrl.operatorConfig.ScheduleOnWorkers = shouldScheduleOnWorkers(infrastructure)
 			relatedObjects = append(relatedObjects, configv1.ObjectReference{
 				Group:    operatorapi.GroupName,
 				Resource: "clustercsidrivers",
@@ -302,10 +301,6 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 	}
 
 	return true
-}
-
-func shouldScheduleOnWorkers(infra *configv1.Infrastructure) bool {
-	return infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
 }
 
 func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {


### PR DESCRIPTION
Partially reverts changes from #187 
Fixes clearing the node selector when control plane topology is set to External.