### PR TITLE
Bug 1989740: Move manila operator role under the manila namespace

### DIFF
--- a/assets/csidriveroperators/manila/03_role.yaml
+++ b/assets/csidriveroperators/manila/03_role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: manila-csi-driver-operator-role
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 rules:
 - apiGroups:
   - ''

--- a/assets/csidriveroperators/manila/04_rolebinding.yaml
+++ b/assets/csidriveroperators/manila/04_rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: manila-csi-driver-operator-rolebinding
-  namespace: openshift-cluster-csi-drivers
+  namespace: openshift-manila-csi-driver
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Manila operands doesn't have access to the
`openshift-cluster-csi-drivers` namespace under which the operator is
deployed. We need to move the role to the `openshift-manila-csi-driver`
namespace.

This has worked until now because the rules are also covered in the
ClusterRole.