### PR TITLE
Bug 2001761: Fix RelatedObjects when RBAC API is missing

### DIFF
--- a/pkg/csoclients/csoclients.go
+++ b/pkg/csoclients/csoclients.go
@@ -1,11 +1,15 @@
 package csoclients
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
+	"time"
+
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"time"
 
 	cfgclientset "github.com/openshift/client-go/config/clientset/versioned"
 	cfginformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -16,10 +20,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	prominformer "github.com/prometheus-operator/prometheus-operator/pkg/client/informers/externalversions"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
-	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 type Clients struct {
@@ -54,7 +54,7 @@ type Clients struct {
 	DynamicClient dynamic.Interface
 
 	// Rest Mapper for mapping GVK to GVR
-	RestMapper       meta.RESTMapper
+	RestMapper       *restmapper.DeferredDiscoveryRESTMapper
 	CategoryExpander restmapper.CategoryExpander
 }
 

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -150,17 +150,17 @@ func (c *CSIDriverStarterController) sync(ctx context.Context, syncCtx factory.S
 			if !shouldRun {
 				continue
 			}
-			relatedObjects = append(relatedObjects, configv1.ObjectReference{
-				Group:    operatorapi.GroupName,
-				Resource: "clustercsidrivers",
-				Name:     ctrl.operatorConfig.CSIDriverName,
-			})
 			// add static assets
 			objs, err := ctrl.ctrlRelatedObjects.RelatedObjects()
 			if err != nil {
 				return err
 			}
 			relatedObjects = append(relatedObjects, objs...)
+			relatedObjects = append(relatedObjects, configv1.ObjectReference{
+				Group:    operatorapi.GroupName,
+				Resource: "clustercsidrivers",
+				Name:     ctrl.operatorConfig.CSIDriverName,
+			})
 			klog.V(2).Infof("Starting ControllerManager for %s", ctrl.operatorConfig.ConditionPrefix)
 			go ctrl.mgr.Start(ctx)
 			ctrl.running = true

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -20,8 +20,11 @@ import (
 	"github.com/openshift/library-go/pkg/operator/status"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	storagelister "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
 )
 
@@ -46,6 +49,7 @@ type CSIDriverStarterController struct {
 	infraLister       openshiftv1.InfrastructureLister
 	featureGateLister openshiftv1.FeatureGateLister
 	csiDriverLister   storagelister.CSIDriverLister
+	restMapper        *restmapper.DeferredDiscoveryRESTMapper
 	versionGetter     status.VersionGetter
 	targetVersion     string
 	eventRecorder     events.Recorder
@@ -77,6 +81,7 @@ func NewCSIDriverStarterController(
 		infraLister:       clients.ConfigInformers.Config().V1().Infrastructures().Lister(),
 		featureGateLister: clients.ConfigInformers.Config().V1().FeatureGates().Lister(),
 		csiDriverLister:   clients.KubeInformers.InformersFor("").Storage().V1().CSIDrivers().Lister(),
+		restMapper:        clients.RestMapper,
 		versionGetter:     versionGetter,
 		targetVersion:     targetVersion,
 		eventRecorder:     eventRecorder.WithComponentSuffix("CSIDriverStarter"),
@@ -153,6 +158,10 @@ func (c *CSIDriverStarterController) sync(ctx context.Context, syncCtx factory.S
 			// add static assets
 			objs, err := ctrl.ctrlRelatedObjects.RelatedObjects()
 			if err != nil {
+				if isNoMatchError(err) {
+					// RESTMapper NoResourceMatch / NoKindMatch errors are cached. Reset the cache to get fresh results on the next sync.
+					c.restMapper.Reset()
+				}
 				return err
 			}
 			relatedObjects = append(relatedObjects, objs...)
@@ -294,4 +303,19 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 	}
 
 	return true
+}
+
+func isNoMatchError(err error) bool {
+	// ctrlRelatedObjects.RelatedObjects() may return aggregated errors, process that
+	if agg, ok := err.(utilerrors.Aggregate); ok {
+		errs := agg.Errors()
+		for _, err := range errs {
+			if meta.IsNoMatchError(err) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return meta.IsNoMatchError(err)
 }

--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -1,12 +1,17 @@
 package csidriveroperator
 
 import (
+	"io/fs"
+	"os"
 	"testing"
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/errors"
 )
 
 func TestShouldRunController(t *testing.T) {
@@ -243,4 +248,77 @@ func csiDriver(csiDriverName string, annotations map[string]string) *storagev1.C
 		},
 		Spec: storagev1.CSIDriverSpec{},
 	}
+}
+
+func TestIsNoMatchError(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "foos",
+	}
+	gvk := schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Foo",
+	}
+	gk := schema.GroupKind{
+		Group: "",
+		Kind:  "foo",
+	}
+
+	tests := []struct {
+		name          string
+		err           error
+		expectNoMatch bool
+	}{
+		{
+			name:          "no error",
+			err:           nil,
+			expectNoMatch: false,
+		},
+		{
+			name:          "NoResourceMatch",
+			err:           &meta.NoResourceMatchError{PartialResource: gvr},
+			expectNoMatch: true,
+		},
+		{
+			name:          "NoKindMatch",
+			err:           &meta.NoKindMatchError{GroupKind: gk},
+			expectNoMatch: true,
+		},
+		{
+			name: "unrelated error",
+			err: &meta.AmbiguousKindError{
+				PartialKind:       gvk,
+				MatchingResources: nil,
+				MatchingKinds:     nil,
+			},
+			expectNoMatch: false,
+		},
+		{
+			name:          "aggregated NoResourceMatch",
+			err:           errors.NewAggregate([]error{&meta.NoResourceMatchError{PartialResource: gvr}, os.ErrPermission}),
+			expectNoMatch: true,
+		},
+		{
+			name:          "aggregated NoKindMatch",
+			err:           errors.NewAggregate([]error{os.ErrPermission, &meta.NoKindMatchError{GroupKind: gk}}),
+			expectNoMatch: true,
+		},
+		{
+			name:          "aggregated unrelated errors",
+			err:           errors.NewAggregate([]error{os.ErrPermission, os.ErrExist, fs.ErrClosed}),
+			expectNoMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ret := isNoMatchError(test.err)
+			if ret != test.expectNoMatch {
+				t.Errorf("expected %t, got %t", test.expectNoMatch, ret)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
When starting a CSI driver operator and discovering its dependencies / `RelatedObjects`, some APIs may be temporarily missing in the API server. RESTMapper is caching the error responses, so make sure to refresh the cache in the next sync.

I tried to fix the caching in [client-go](https://github.com/kubernetes/kubernetes/pull/104814), but it seems it's not going anywhere.