### PR TITLE
Install vSphere CSI Driver and Operator by default

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
@@ -33,10 +33,9 @@ func GetVMwareVSphereCSIOperatorConfig() CSIOperatorConfig {
 			"csidriveroperators/vsphere/06_clusterrole.yaml",
 			"csidriveroperators/vsphere/07_clusterrolebinding.yaml",
 		},
-		CRAsset:            "csidriveroperators/vsphere/09_cr.yaml",
-		DeploymentAsset:    "csidriveroperators/vsphere/08_deployment.yaml",
-		ImageReplacer:      strings.NewReplacer(pairs...),
-		AllowDisabled:      false,
-		RequireFeatureGate: "CSIDriverVSphere",
+		CRAsset:         "csidriveroperators/vsphere/09_cr.yaml",
+		DeploymentAsset: "csidriveroperators/vsphere/08_deployment.yaml",
+		ImageReplacer:   strings.NewReplacer(pairs...),
+		AllowDisabled:   false,
 	}
 }


### PR DESCRIPTION
vSphere CSI Driver & Operator are going to be GA in 4.10, so they need to be installed by default.

CC @openshift/storage 