### PR TITLE
Revert "Install vSphere CSI Driver by default"

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
@@ -33,9 +33,10 @@ func GetVMwareVSphereCSIOperatorConfig() CSIOperatorConfig {
 			"csidriveroperators/vsphere/06_clusterrole.yaml",
 			"csidriveroperators/vsphere/07_clusterrolebinding.yaml",
 		},
-		CRAsset:         "csidriveroperators/vsphere/09_cr.yaml",
-		DeploymentAsset: "csidriveroperators/vsphere/08_deployment.yaml",
-		ImageReplacer:   strings.NewReplacer(pairs...),
-		AllowDisabled:   false,
+		CRAsset:            "csidriveroperators/vsphere/09_cr.yaml",
+		DeploymentAsset:    "csidriveroperators/vsphere/08_deployment.yaml",
+		ImageReplacer:      strings.NewReplacer(pairs...),
+		AllowDisabled:      false,
+		RequireFeatureGate: "CSIDriverVSphere",
 	}
 }


### PR DESCRIPTION
This reverts commit 0134c1c0d3442465a74c3c4a880202451ffd4861.
The vsphere CSI driver is producing large numbers of client requests.
Our vCenter instances cannot support the vsphere csi driver running on
many concurrent CI clusters without starving some vsphere clusters.

We need to revert this PR until the number of connections can be reduced
so that we can keep running multiple concurrent CI clusters.

stop-gap for https://bugzilla.redhat.com/show_bug.cgi?id=2009859 to get back to a functional CI state.