### PR TITLE
Bug 2010310: set summary and description for alerts

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -17,6 +17,11 @@ spec:
         labels:
           severity: warning
         annotations:
+          summary: "VSphere node health checks are failing"
+          description: |
+            The vsphere-problem-detector performs health checks on individual OpenShift nodes on 
+            VSphere to confirm configuration and performance requirements are met.  Health checks 
+            verify machine scaling, storage provisioning, and node performance meet requirements.
           message: "VSphere health check {{ $labels.check }} is failing on {{ $labels.node }}."
       - alert: VSphereOpenshiftClusterHealthFail
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
@@ -26,6 +31,11 @@ spec:
         labels:
           severity: warning
         annotations:
+          summary: "VSphere cluster health checks are failing"
+          description: |
+            The vsphere-problem-detector monitors the health and configuration of OpenShift on
+            VSphere.  If problems are found which may prevent machine scaling, storage provisioning,
+            and safe upgrades, the vsphere-problem-detector will raise alerts.
           message: "VSphere cluster health checks are failing with {{ $labels.check }}"
       - alert: VSphereOpenshiftConnectionFailure
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.


### PR DESCRIPTION
4.10 vSphere CI testing is failing due to defined alerts with undefined summary and description fields.  The intent of this PR is to define those fields.

~~~
Alerting rule "VSphereOpenshiftClusterHealthFail" (group: vsphere-problem-detector.rules) has no 'description' annotation, but has a 'message' annotation. OpenShift alerts must use 'description' -- consider renaming the annotation
Alerting rule "VSphereOpenshiftClusterHealthFail" (group: vsphere-problem-detector.rules) has no 'summary' annotation
Alerting rule "VSphereOpenshiftNodeHealthFail" (group: vsphere-problem-detector.rules) has no 'description' annotation, but has a 'message' annotation. OpenShift alerts must use 'description' -- consider renaming the annotation
Alerting rule "VSphereOpenshiftNodeHealthFail" (group: vsphere-problem-detector.rules) has no 'summary' annotation
~~~