### PR TITLE
Bug 2009859: Install vSphere CSI Driver by default (again)

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
@@ -33,10 +33,9 @@ func GetVMwareVSphereCSIOperatorConfig() CSIOperatorConfig {
 			"csidriveroperators/vsphere/06_clusterrole.yaml",
 			"csidriveroperators/vsphere/07_clusterrolebinding.yaml",
 		},
-		CRAsset:            "csidriveroperators/vsphere/09_cr.yaml",
-		DeploymentAsset:    "csidriveroperators/vsphere/08_deployment.yaml",
-		ImageReplacer:      strings.NewReplacer(pairs...),
-		AllowDisabled:      false,
-		RequireFeatureGate: "CSIDriverVSphere",
+		CRAsset:         "csidriveroperators/vsphere/09_cr.yaml",
+		DeploymentAsset: "csidriveroperators/vsphere/08_deployment.yaml",
+		ImageReplacer:   strings.NewReplacer(pairs...),
+		AllowDisabled:   false,
 	}
 }


### PR DESCRIPTION
We believe we fixed the leaking of sessions in the vSphere CSI Driver Operator [1], so we will install the vSphere CSI Driver Operator on all vSphere clusters again and see how it goes.

CC @rvanderp3 @deads2k @openshift/storage

[1] https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/47
