### PR TITLE
WIP: Optimize certificate syncing

### DIFF
--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -49,8 +49,9 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manila-csi-driver-operator
         volumeMounts:
-        - name: cacert
-          mountPath: /etc/openstack-ca/
+        - name: trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
         - name: cloud-credentials
           # Create /etc/openstack/clouds.yaml
           mountPath: /etc/openstack/
@@ -69,17 +70,12 @@ spec:
         operator: Exists
         effect: "NoSchedule"
       volumes:
-      - name: cacert
-        # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
-        # Let the pod start when the ConfigMap does not exist or the certificate
-        # is not preset there. The certificate file will be created once the
-        # ConfigMap is created / the cerificate is added to it.
+      - name: trusted-ca
         configMap:
-          name: cloud-provider-config
+          name: trusted-ca
           items:
-            - key: ca-bundle.pem
-              path: ca-bundle.pem
-          optional: true
+            - key: ca-bundle.crt 
+              path: tls-ca-bundle.pem
       - name: cloud-credentials
         secret:
           secretName: manila-cloud-credentials

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: secret-cinderplugin
           mountPath: /etc/openstack
           readOnly: true
-        - name: cacert
-          mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
+        - name: trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
         name: openstack-cinder-csi-driver-operator
         resources:
           requests:
@@ -71,15 +72,9 @@ spec:
           items:
             - key: clouds.yaml
               path: clouds.yaml
-      - name: cacert
-        # If present, extract ca-bundle.pem to
-        # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-        # Let the pod start when the ConfigMap does not exist or the certificate
-        # is not preset there. The certificate file will be created once the
-        # ConfigMap is created / the cerificate is added to it.
+      - name: trusted-ca
         configMap:
-          name: cloud-provider-config
+          name: trusted-ca
           items:
-          - key: ca-bundle.pem
-            path: ca-bundle.pem
-          optional: true
+            - key: ca-bundle.crt 
+              path: tls-ca-bundle.pem

--- a/manifests/0000_49_cluster-storage-operator_02_trusted-ca-configmap.yaml
+++ b/manifests/0000_49_cluster-storage-operator_02_trusted-ca-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: mao-trusted-ca
+  namespace: openshift-cluster-storage-operator


### PR DESCRIPTION
According to [1] we should not implement our own certificate syncer, but rather use one provided by CNO. To use it correctly we need to create an empty config map, and after that we will get another cm with the certificate.

[1] https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#certificate-injection-using-operators_configuring-a-custom-pki