### PR TITLE
Add Azure File CSI Driver installation (TP)

### DIFF
--- a/assets/csidriveroperators/azure-file/03_sa.yaml
+++ b/assets/csidriveroperators/azure-file/03_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: azure-file-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/azure-file/04_role.yaml
+++ b/assets/csidriveroperators/azure-file/04_role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: azure-file-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/azure-file/05_rolebinding.yaml
+++ b/assets/csidriveroperators/azure-file/05_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: azure-file-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: azure-file-csi-driver-operator-role
+subjects:
+- kind: ServiceAccount
+  name: azure-file-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/azure-file/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/06_clusterrole.yaml
@@ -1,0 +1,277 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: azure-file-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers
+  verbs:
+  - get
+  - list
+  - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - azure-file-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - watch
+  - list
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"

--- a/assets/csidriveroperators/azure-file/07_clusterrolebinding.yaml
+++ b/assets/csidriveroperators/azure-file/07_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: azure-file-csi-driver-operator-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: azure-file-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: azure-file-csi-driver-operator-clusterrole

--- a/assets/csidriveroperators/azure-file/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-file/08_deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azure-file-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: azure-file-csi-driver-operator
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: azure-file-csi-driver-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=${LOG_LEVEL}
+        env:
+        - name: DRIVER_IMAGE
+          value: ${DRIVER_IMAGE}
+        - name: PROVISIONER_IMAGE
+          value: ${PROVISIONER_IMAGE}
+        - name: ATTACHER_IMAGE
+          value: ${ATTACHER_IMAGE}
+        - name: RESIZER_IMAGE
+          value: ${RESIZER_IMAGE}
+        - name: SNAPSHOTTER_IMAGE
+          value: ${SNAPSHOTTER_IMAGE}
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        - name: LIVENESS_PROBE_IMAGE
+          value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: azure-file-csi-driver-operator
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+      priorityClassName: system-cluster-critical
+      serviceAccountName: azure-file-csi-driver-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"

--- a/assets/csidriveroperators/azure-file/09_cr.yaml
+++ b/assets/csidriveroperators/azure-file/09_cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: file.csi.azure.com
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -1,0 +1,19 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: azure-file-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor
+  secretRef:
+    name: azure-file-credentials
+    namespace: openshift-cluster-csi-drivers
+

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -67,6 +67,10 @@ spec:
           value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver-operator
         - name: AZURE_DISK_DRIVER_IMAGE
           value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+        - name: AZURE_FILE_DRIVER_OPERATOR_IMAGE
+          value: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver-operator
+        - name: AZURE_FILE_DRIVER_IMAGE
+          value: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver
         - name: KUBE_RBAC_PROXY_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -96,6 +96,12 @@ spec:
           - name: AZURE_DISK_DRIVER_IMAGE
             # TODO: replace with quay.io when the image is mirrored
             value: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+          - name: AZURE_FILE_DRIVER_OPERATOR_IMAGE
+            # TODO: replace with quay.io when the image is mirrored
+            value: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver-operator
+          - name: AZURE_FILE_DRIVER_IMAGE
+            # TODO: replace with quay.io when the image is mirrored
+            value: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver
           - name: KUBE_RBAC_PROXY_IMAGE
             value: quay.io/openshift/origin-kube-rbac-proxy:latest
           - name: VMWARE_VSPHERE_DRIVER_OPERATOR_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -98,6 +98,14 @@ spec:
     from:
       kind: DockerImage
       name: registry.ci.openshift.org/ocp/4.8:azure-disk-csi-driver
+  - name: azure-file-csi-driver-operator
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver-operator
+  - name: azure-file-csi-driver
+    from:
+      kind: DockerImage
+      name: registry.ci.openshift.org/ocp/4.10:azure-file-csi-driver
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
@@ -1,0 +1,39 @@
+package csioperatorclient
+
+import (
+	"os"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	AzureFileDriverName             = "file.csi.azure.com"
+	envAzureFileDriverOperatorImage = "AZURE_FILE_DRIVER_OPERATOR_IMAGE"
+	envAzureFileDriverImage         = "AZURE_FILE_DRIVER_IMAGE"
+)
+
+func GetAzureFileCSIOperatorConfig() CSIOperatorConfig {
+	pairs := []string{
+		"${OPERATOR_IMAGE}", os.Getenv(envAzureFileDriverOperatorImage),
+		"${DRIVER_IMAGE}", os.Getenv(envAzureFileDriverImage),
+	}
+
+	return CSIOperatorConfig{
+		CSIDriverName:   AzureFileDriverName,
+		ConditionPrefix: "AzureFile",
+		Platform:        configv1.AzurePlatformType,
+		StaticAssets: []string{
+			"csidriveroperators/azure-file/03_sa.yaml",
+			"csidriveroperators/azure-file/04_role.yaml",
+			"csidriveroperators/azure-file/05_rolebinding.yaml",
+			"csidriveroperators/azure-file/06_clusterrole.yaml",
+			"csidriveroperators/azure-file/07_clusterrolebinding.yaml",
+		},
+		CRAsset:            "csidriveroperators/azure-file/09_cr.yaml",
+		DeploymentAsset:    "csidriveroperators/azure-file/08_deployment.yaml",
+		ImageReplacer:      strings.NewReplacer(pairs...),
+		AllowDisabled:      false,
+		RequireFeatureGate: "CSIDriverAzureFile",
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -133,5 +133,6 @@ func populateConfigs(clients *csoclients.Clients, recorder events.Recorder) []cs
 		csioperatorclient.GetManilaOperatorConfig(clients, recorder),
 		csioperatorclient.GetVMwareVSphereCSIOperatorConfig(),
 		csioperatorclient.GetAzureDiskCSIOperatorConfig(),
+		csioperatorclient.GetAzureFileCSIOperatorConfig(),
 	}
 }


### PR DESCRIPTION
Azure File CSI Driver Operator & Driver are TechPreview in 4.10. Install them when the `TechPreviewNoUPgrade` FeatureSet is set.

CC @openshift/storage
