### PR TITLE
Bug 2015635: Remove Azure Stack Hub detection.

### DIFF
--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -243,13 +243,6 @@ func shouldRunController(cfg csioperatorclient.CSIOperatorConfig, infrastructure
 		return true, nil
 	}
 
-	// For Azure Stack Hub we have to enable the CSI driver because it does not support
-	// in-tree volume plugin for azure disk.
-	if isAzureStackHub(infrastructure.Status.PlatformStatus) {
-		klog.V(5).Infof("Starting %s for Azure Stack Hub", cfg.CSIDriverName)
-		return true, nil
-	}
-
 	if !featureGateEnabled(fg, cfg.RequireFeatureGate) {
 		klog.V(4).Infof("Not starting %s: feature %s is not enabled", cfg.CSIDriverName, cfg.RequireFeatureGate)
 		return false, nil
@@ -301,8 +294,4 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 	}
 
 	return true
-}
-
-func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
-	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }

--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -186,33 +186,6 @@ func TestShouldRunController(t *testing.T) {
 	}
 }
 
-func TestShouldRunControllerAzureStackHub(t *testing.T) {
-	infra := &v1.Infrastructure{
-		Status: v1.InfrastructureStatus{
-			PlatformStatus: &v1.PlatformStatus{
-				Type: v1.AzurePlatformType,
-				Azure: &v1.AzurePlatformStatus{
-					CloudName: v1.AzureStackCloud,
-				},
-			},
-		},
-	}
-
-	config := csioperatorclient.CSIOperatorConfig{
-		CSIDriverName:      "disk.csi.azure.com",
-		Platform:           v1.AzurePlatformType,
-		RequireFeatureGate: "CSIDriverAzureDisk",
-	}
-
-	res, err := shouldRunController(config, infra, nil, nil)
-	if err != nil {
-		t.Errorf("Unexpected error occurred: %v", err)
-	}
-	if !res {
-		t.Error("Expected to run controller for Azure Stack Hub")
-	}
-}
-
 func featureSet(set v1.FeatureSet) *v1.FeatureGate {
 	return &v1.FeatureGate{
 		Spec: v1.FeatureGateSpec{


### PR DESCRIPTION
Azure Disk CSI driver is installed by default, both on Azure cloud and Azure stack. We don't need to distinguish these two platform any longer.

As side effect, this will stop installing Azure File CSI driver operator on Azure Stack Hub. It should be installed via TechPreviewNoUpgrade there too.

This reverts PR #200.

cc @openshift/storage 
