### PR TITLE
Update Shared Resource Operator permissions

### DIFF
--- a/assets/csidriveroperators/shared-resource/05_clusterrole.yaml
+++ b/assets/csidriveroperators/shared-resource/05_clusterrole.yaml
@@ -88,9 +88,20 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
-  - list
   - create
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  resourceNames:
+  - sharedconfigmaps.sharedresource.openshift.io
+  - sharedsecrets.sharedresource.openshift.io
+  verbs:
+  - get
+  - list
   - watch
+  - update
+  - patch
   - delete
 - apiGroups:
   - coordination.k8s.io
@@ -110,6 +121,7 @@ rules:
   - secrets
   - configmaps
   verbs:
+  - create
   - get
   - list
   - watch


### PR DESCRIPTION
Reign in the Shared Resource Operator permissions
for Custom Resource Definitions.

We need a blanket CREATE permission for ALL CRDs
But only need list,get,watch,delete for sharedconfigmaps and
sharedsecrets.