### PR TITLE
WIP: BUILD-256: add shared resource driver configuration configmap

### DIFF
--- a/manifests/13_config_configmap.yaml
+++ b/manifests/13_config_configmap.yaml
@@ -1,0 +1,37 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: csi-driver-shared-resource-config
+  namespace: openshift-cluster-csi-drivers
+data:
+  config.yaml: |
+    ---
+    ignoredNamespaces:
+      - openshift-machine-api
+      - openshift-kube-apiserver
+      - openshift-kube-apiserver-operator
+      - openshift-kube-scheduler
+      - openshift-kube-controller-manager
+      - openshift-kube-controller-manager-operator
+      - openshift-kube-scheduler-operator
+      - openshift-console-operator
+      - openshift-controller-manager
+      - openshift-controller-manager-operator
+      - openshift-cloud-credential-operator
+      - openshift-authentication-operator
+      - openshift-service-ca
+      - openshift-kube-storage-version-migrator-operator
+      - openshift-config-operator
+      - openshift-etcd-operator
+      - openshift-apiserver-operator
+      - openshift-cluster-csi-drivers
+      - openshift-cluster-storage-operator
+      - openshift-cluster-version
+      - openshift-image-registry
+      - openshift-machine-config-operator
+      - openshift-sdn
+      - openshift-service-ca-operator
+
+    refreshResources: true
+
+    shareRelistInterval: 10m


### PR DESCRIPTION
proved we could not use library-go static resource controller in shared resource operator;
it is truly "static" ... if we change the data field, the controller changes it back

but putting it in assets leverages the static resource controller as well in this repo (thanks for the reminder @coreydaley )

creating  WIP PR with putting it in the CSO manifest, so the CVO creates it, similar to our other CVO based controllers

will launch cluster bot cluster to test if we can change 

otherwise, we are back to the SRO either "manually" creating the configmap outside of library-go, or having to employ configobservers to deal with it 

