### PR TITLE
Add Alibaba Disk CSI driver

### DIFF
--- a/assets/csidriveroperators/alibaba-disk/02_sa.yaml
+++ b/assets/csidriveroperators/alibaba-disk/02_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alibaba-disk-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/alibaba-disk/03_role.yaml
+++ b/assets/csidriveroperators/alibaba-disk/03_role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alibaba-disk-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/assets/csidriveroperators/alibaba-disk/04_rolebinding.yaml
+++ b/assets/csidriveroperators/alibaba-disk/04_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alibaba-disk-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alibaba-disk-csi-driver-operator-role
+subjects:
+- kind: ServiceAccount
+  name: alibaba-disk-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
+++ b/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
@@ -1,0 +1,269 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alibaba-disk-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers
+  verbs:
+  - get
+  - list
+  - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - alibaba-disk-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics.
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"

--- a/assets/csidriveroperators/alibaba-disk/06_clusterrolebinding.yaml
+++ b/assets/csidriveroperators/alibaba-disk/06_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: alibaba-disk-csi-driver-operator-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: alibaba-disk-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alibaba-disk-csi-driver-operator-clusterrole

--- a/assets/csidriveroperators/alibaba-disk/07_deployment.yaml
+++ b/assets/csidriveroperators/alibaba-disk/07_deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alibaba-disk-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: alibaba-disk-csi-driver-operator
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: alibaba-disk-csi-driver-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=${LOG_LEVEL}
+        env:
+        - name: DRIVER_IMAGE
+          value: ${DRIVER_IMAGE}
+        - name: PROVISIONER_IMAGE
+          value: ${PROVISIONER_IMAGE}
+        - name: ATTACHER_IMAGE
+          value: ${ATTACHER_IMAGE}
+        - name: RESIZER_IMAGE
+          value: ${RESIZER_IMAGE}
+        - name: SNAPSHOTTER_IMAGE
+          value: ${SNAPSHOTTER_IMAGE}
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        - name: LIVENESS_PROBE_IMAGE
+          value: ${LIVENESS_PROBE_IMAGE}
+        - name: KUBE_RBAC_PROXY_IMAGE
+          value: ${KUBE_RBAC_PROXY_IMAGE}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: alibaba-disk-csi-driver-operator
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+      priorityClassName: system-cluster-critical
+      serviceAccountName: alibaba-disk-csi-driver-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"

--- a/assets/csidriveroperators/alibaba-disk/08_cr.yaml
+++ b/assets/csidriveroperators/alibaba-disk/08_cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: "ClusterCSIDriver"
+metadata:
+  name: "diskplugin.csi.alibabacloud.com"
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -85,6 +85,10 @@ spec:
           value: quay.io/openshift/origin-csi-driver-shared-resource-operator:latest
         - name: SHARED_RESOURCE_DRIVER_IMAGE
           value: quay.io/openshift/origin-csi-driver-shared-resource:latest
+        - name: ALIBABA_DISK_DRIVER_OPERATOR_IMAGE
+          value: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
+        - name: ALIBABA_CLOUD_DRIVER_IMAGE
+          value: quay.io/openshift/origin-alibaba-cloud-csi-driver:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -119,6 +119,10 @@ spec:
             value: quay.io/openshift/origin-csi-driver-shared-resource-operator:latest
           - name: SHARED_RESOURCE_DRIVER_IMAGE
             value: quay.io/openshift/origin-csi-driver-shared-resource:latest
+          - name: ALIBABA_DISK_DRIVER_OPERATOR_IMAGE
+            value: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
+          - name: ALIBABA_CLOUD_DRIVER_IMAGE
+            value: quay.io/openshift/origin-alibaba-cloud-csi-driver:latest
           resources:
             requests:
               cpu: 10m

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -122,3 +122,11 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-csi-driver-shared-resource:latest
+  - name: alibaba-disk-csi-driver-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
+  - name: alibaba-cloud-csi-driver
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-alibaba-cloud-csi-driver:latest

--- a/pkg/operator/csidriveroperator/csioperatorclient/alibaba-disk.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/alibaba-disk.go
@@ -1,0 +1,38 @@
+package csioperatorclient
+
+import (
+	"os"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+const (
+	AlibabaDiskCSIDriverName          = "diskplugin.csi.alibabacloud.com"
+	envAlibabaDiskDriverOperatorImage = "ALIBABA_DISK_DRIVER_OPERATOR_IMAGE"
+	envAlibabaCloudDriverImage        = "ALIBABA_CLOUD_DRIVER_IMAGE"
+)
+
+func GetAlibabaDiskCSIOperatorConfig() CSIOperatorConfig {
+	pairs := []string{
+		"${OPERATOR_IMAGE}", os.Getenv(envAlibabaDiskDriverOperatorImage),
+		"${DRIVER_IMAGE}", os.Getenv(envAlibabaCloudDriverImage),
+	}
+
+	return CSIOperatorConfig{
+		CSIDriverName:   AlibabaDiskCSIDriverName,
+		ConditionPrefix: "AlibabaDisk",
+		Platform:        configv1.AlibabaCloudPlatformType,
+		StaticAssets: []string{
+			"csidriveroperators/alibaba-disk/02_sa.yaml",
+			"csidriveroperators/alibaba-disk/03_role.yaml",
+			"csidriveroperators/alibaba-disk/04_rolebinding.yaml",
+			"csidriveroperators/alibaba-disk/05_clusterrole.yaml",
+			"csidriveroperators/alibaba-disk/06_clusterrolebinding.yaml",
+		},
+		CRAsset:         "csidriveroperators/alibaba-disk/08_cr.yaml",
+		DeploymentAsset: "csidriveroperators/alibaba-disk/07_deployment.yaml",
+		ImageReplacer:   strings.NewReplacer(pairs...),
+		AllowDisabled:   false,
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -135,5 +135,6 @@ func populateConfigs(clients *csoclients.Clients, recorder events.Recorder) []cs
 		csioperatorclient.GetAzureDiskCSIOperatorConfig(),
 		csioperatorclient.GetAzureFileCSIOperatorConfig(),
 		csioperatorclient.GetSharedResourceCSIOperatorConfig(),
+		csioperatorclient.GetAlibabaDiskCSIOperatorConfig(),
 	}
 }


### PR DESCRIPTION
Tested with force-installing the driver on AWS, it needs https://github.com/openshift/alibaba-disk-csi-driver-operator/pull/12, but otherwise it started the CSI driver DaemonSet + Deployment. Driver pods crashed because they were running on a wrong cloud.