### PR TITLE
Bug 2030364: Setup port, mount TLS cert into CSI shared resource operator

### DIFF
--- a/assets/csidriveroperators/shared-resource/09_deployment.yaml
+++ b/assets/csidriveroperators/shared-resource/09_deployment.yaml
@@ -36,6 +36,13 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
+        ports:
+        - name: provisioner-m
+          containerPort: 6000
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/secrets
+          name: shared-resource-csi-driver-operator-metrics-serving-cert
       priorityClassName: system-cluster-critical
       serviceAccountName: shared-resource-csi-driver-operator
       nodeSelector:
@@ -46,3 +53,8 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
+      volumes:
+      - name: shared-resource-csi-driver-operator-metrics-serving-cert
+        secret:
+          defaultMode: 420
+          secretName: shared-resource-csi-driver-operator-metrics-serving-cert


### PR DESCRIPTION
Currently CSI shared resource operator pod does not know about the TLS certificate it has to use and the port for the metrics. That should be changed in the deployment.