### PR TITLE
Remove invalid -v argument from IBM VPC operator deployment

### DIFF
--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
       - args:
         - start
-        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}


### PR DESCRIPTION
This line was not intended to be included in https://github.com/openshift/cluster-storage-operator/pull/242
It's causing the deployment to fail:
```
root@3065a3db5912:/go/src/github.com/openshift/installer# oc --kubeconfig cluster-deploys/ipi-dev-storage-10/auth/kubeconfig logs -n openshift-cluster-csi-drivers ibm-vpc-block-csi-driver-operator-55d7b64d85-wpcs4 
Error: unknown shorthand flag: 'v' in -v=2
Usage:
  ibm-vpc-block-csi-driver-operator start [flags]

Flags:
      --config string                    Location of the master configuration file to run from.
  -h, --help                             help for start
      --kubeconfig string                Location of the master configuration file to run from.
      --listen string                    The ip:port to serve on.
      --namespace string                 Namespace where the controller is running. Auto-detected if run in cluster.
      --terminate-on-files stringArray   A list of files. If one of them changes, the process will terminate.

unknown shorthand flag: 'v' in -v=2
```
/cc @openshift/storage 