### PR TITLE
[4.7] Bug 2030740: Add trusted CA bundle to vsphere operators

### DIFF
--- a/assets/vsphere_problem_detector/06_configmap.yaml
+++ b/assets/vsphere_problem_detector/06_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    # This label ensures that the OpenShift Certificate Authority bundle
+    # is added to the ConfigMap.
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca-bundle
+  namespace: openshift-cluster-storage-operator

--- a/assets/vsphere_problem_detector/07_deployment.yaml
+++ b/assets/vsphere_problem_detector/07_deployment.yaml
@@ -38,6 +38,9 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: vsphere-problem-detector-serving-cert
+        - name: trusted-ca-bundle
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
       priorityClassName: system-cluster-critical
       serviceAccountName: vsphere-problem-detector-operator
       nodeSelector:
@@ -53,3 +56,9 @@ spec:
         secret:
           secretName: vsphere-problem-detector-serving-cert
           optional: true
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem

--- a/pkg/dependencymagnet/dependencymagnet.go
+++ b/pkg/dependencymagnet/dependencymagnet.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // go mod won't pull in code that isn't depended upon, but we have some code we don't depend on from code that must be included

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -52,7 +52,8 @@
 // assets/vsphere_problem_detector/03_rolebinding.yaml
 // assets/vsphere_problem_detector/04_clusterrole.yaml
 // assets/vsphere_problem_detector/05_clusterrolebinding.yaml
-// assets/vsphere_problem_detector/06_deployment.yaml
+// assets/vsphere_problem_detector/06_configmap.yaml
+// assets/vsphere_problem_detector/07_deployment.yaml
 // assets/vsphere_problem_detector/10_service.yaml
 // assets/vsphere_problem_detector/11_service_monitor.yaml
 // assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -3313,7 +3314,33 @@ func vsphere_problem_detector05_clusterrolebindingYaml() (*asset, error) {
 	return a, nil
 }
 
-var _vsphere_problem_detector06_deploymentYaml = []byte(`apiVersion: apps/v1
+var _vsphere_problem_detector06_configmapYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    # This label ensures that the OpenShift Certificate Authority bundle
+    # is added to the ConfigMap.
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca-bundle
+  namespace: openshift-cluster-storage-operator
+`)
+
+func vsphere_problem_detector06_configmapYamlBytes() ([]byte, error) {
+	return _vsphere_problem_detector06_configmapYaml, nil
+}
+
+func vsphere_problem_detector06_configmapYaml() (*asset, error) {
+	bytes, err := vsphere_problem_detector06_configmapYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "vsphere_problem_detector/06_configmap.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _vsphere_problem_detector07_deploymentYaml = []byte(`apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vsphere-problem-detector-operator
@@ -3353,6 +3380,9 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: vsphere-problem-detector-serving-cert
+        - name: trusted-ca-bundle
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
       priorityClassName: system-cluster-critical
       serviceAccountName: vsphere-problem-detector-operator
       nodeSelector:
@@ -3368,19 +3398,25 @@ spec:
         secret:
           secretName: vsphere-problem-detector-serving-cert
           optional: true
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
 `)
 
-func vsphere_problem_detector06_deploymentYamlBytes() ([]byte, error) {
-	return _vsphere_problem_detector06_deploymentYaml, nil
+func vsphere_problem_detector07_deploymentYamlBytes() ([]byte, error) {
+	return _vsphere_problem_detector07_deploymentYaml, nil
 }
 
-func vsphere_problem_detector06_deploymentYaml() (*asset, error) {
-	bytes, err := vsphere_problem_detector06_deploymentYamlBytes()
+func vsphere_problem_detector07_deploymentYaml() (*asset, error) {
+	bytes, err := vsphere_problem_detector07_deploymentYamlBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "vsphere_problem_detector/06_deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "vsphere_problem_detector/07_deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3623,7 +3659,8 @@ var _bindata = map[string]func() (*asset, error){
 	"vsphere_problem_detector/03_rolebinding.yaml":                   vsphere_problem_detector03_rolebindingYaml,
 	"vsphere_problem_detector/04_clusterrole.yaml":                   vsphere_problem_detector04_clusterroleYaml,
 	"vsphere_problem_detector/05_clusterrolebinding.yaml":            vsphere_problem_detector05_clusterrolebindingYaml,
-	"vsphere_problem_detector/06_deployment.yaml":                    vsphere_problem_detector06_deploymentYaml,
+	"vsphere_problem_detector/06_configmap.yaml":                     vsphere_problem_detector06_configmapYaml,
+	"vsphere_problem_detector/07_deployment.yaml":                    vsphere_problem_detector07_deploymentYaml,
 	"vsphere_problem_detector/10_service.yaml":                       vsphere_problem_detector10_serviceYaml,
 	"vsphere_problem_detector/11_service_monitor.yaml":               vsphere_problem_detector11_service_monitorYaml,
 	"vsphere_problem_detector/12_prometheusrules.yaml":               vsphere_problem_detector12_prometheusrulesYaml,
@@ -3737,7 +3774,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"03_rolebinding.yaml":        {vsphere_problem_detector03_rolebindingYaml, map[string]*bintree{}},
 		"04_clusterrole.yaml":        {vsphere_problem_detector04_clusterroleYaml, map[string]*bintree{}},
 		"05_clusterrolebinding.yaml": {vsphere_problem_detector05_clusterrolebindingYaml, map[string]*bintree{}},
-		"06_deployment.yaml":         {vsphere_problem_detector06_deploymentYaml, map[string]*bintree{}},
+		"06_configmap.yaml":          {vsphere_problem_detector06_configmapYaml, map[string]*bintree{}},
+		"07_deployment.yaml":         {vsphere_problem_detector07_deploymentYaml, map[string]*bintree{}},
 		"10_service.yaml":            {vsphere_problem_detector10_serviceYaml, map[string]*bintree{}},
 		"11_service_monitor.yaml":    {vsphere_problem_detector11_service_monitorYaml, map[string]*bintree{}},
 		"12_prometheusrules.yaml":    {vsphere_problem_detector12_prometheusrulesYaml, map[string]*bintree{}},

--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_deployment.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_deployment.go
@@ -76,7 +76,7 @@ func (c *VSphereProblemDetectorDeploymentController) sync(ctx context.Context, s
 	}
 
 	replacer := strings.NewReplacer(pairs...)
-	required := csoutils.GetRequiredDeployment("vsphere_problem_detector/06_deployment.yaml", opSpec, replacer)
+	required := csoutils.GetRequiredDeployment("vsphere_problem_detector/07_deployment.yaml", opSpec, replacer)
 
 	requiredCopy, err := util.InjectObservedProxyInDeploymentContainers(required, opSpec)
 	if err != nil {

--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
@@ -103,6 +103,7 @@ func (c *VSphereProblemDetectorStarter) createVSphereProblemDetectorManager(
 		"vsphere_problem_detector/03_rolebinding.yaml",
 		"vsphere_problem_detector/04_clusterrole.yaml",
 		"vsphere_problem_detector/05_clusterrolebinding.yaml",
+		"vsphere_problem_detector/06_configmap.yaml",
 		"vsphere_problem_detector/10_service.yaml",
 	}
 


### PR DESCRIPTION
Use cluster's CA bundle when talking to vCenter.

Backport of https://github.com/openshift/cluster-storage-operator/pull/178 to 4.7

cc @openshift/storage 