### PR TITLE
Bug 2033111: IBM VPC operator library bump removed global CLI args

### DIFF
--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
       - args:
         - start
+        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2033111
/hold
until https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/11 merges
That PR is required first to add the `-v` argument back to the operator
/cc @openshift/storage 