### PR TITLE
no CredentialsRequests in ibm-cloud-managed

### DIFF
--- a/manifests/03_credentials_request_alibaba.yaml
+++ b/manifests/03_credentials_request_alibaba.yaml
@@ -4,7 +4,6 @@ metadata:
   name: alibaba-disk-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -4,7 +4,6 @@ metadata:
   name: aws-ebs-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -4,7 +4,6 @@ metadata:
   name: azure-disk-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -4,7 +4,6 @@ metadata:
   name: azure-file-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_ibm.yaml
+++ b/manifests/03_credentials_request_ibm.yaml
@@ -4,7 +4,6 @@ metadata:
    name: ibm-vpc-block-csi-driver-operator
    namespace: openshift-cloud-credential-operator
    annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   secretRef:

--- a/manifests/03_credentials_request_manila.yaml
+++ b/manifests/03_credentials_request_manila.yaml
@@ -4,7 +4,6 @@ metadata:
   name: manila-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_ovirt.yaml
+++ b/manifests/03_credentials_request_ovirt.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ovirt-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_vsphere_csi.yaml
+++ b/manifests/03_credentials_request_vsphere_csi.yaml
@@ -4,7 +4,6 @@ metadata:
   name: openshift-vmware-vsphere-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/03_credentials_request_vsphere_detector.yaml
+++ b/manifests/03_credentials_request_vsphere_detector.yaml
@@ -4,7 +4,6 @@ metadata:
   name: openshift-vsphere-problem-detector
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/ibm-cloud-managed-cleanup.yaml
+++ b/manifests/ibm-cloud-managed-cleanup.yaml
@@ -1,0 +1,80 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: alibaba-disk-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: aws-ebs-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: azure-disk-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: azure-file-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+   name: ibm-vpc-block-csi-driver-operator
+   namespace: openshift-cloud-credential-operator
+   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: manila-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: ovirt-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-vmware-vsphere-csi-driver-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-vsphere-problem-detector
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
The ibm-cloud-managed profile doesn't use the cloud-credential-operator.
The CredentialsRequest CRs should not be installed in that environment.

Unmark the existing CredentialsRequests so they are no longer installed
in ibm-cloud-managed.

Create a list of previously-installed CredentialsRequests so that they
are cleaned up by the CVO only on the ibm-cloud-managed profile.

xref: https://issues.redhat.com/browse/CCO-177