### PR TITLE
Bug 2043130: Update CSI sidecars to the latest release for 4.10

### DIFF
--- a/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/05_clusterrole.yaml
@@ -225,6 +225,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -234,6 +235,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
@@ -233,6 +233,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -242,6 +243,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/azure-file/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/06_clusterrole.yaml
@@ -231,6 +231,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -240,6 +241,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
+++ b/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
@@ -225,6 +225,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -234,6 +235,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/ibm-vpc-block/06_clusterrole.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/06_clusterrole.yaml
@@ -225,6 +225,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -234,6 +235,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -202,6 +202,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -211,6 +212,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
@@ -216,6 +216,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -225,6 +226,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -198,6 +198,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -207,6 +208,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/shared-resource/05_clusterrole.yaml
+++ b/assets/csidriveroperators/shared-resource/05_clusterrole.yaml
@@ -253,6 +253,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -262,6 +263,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -231,6 +231,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -240,6 +241,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
This adds the new required RBAC rules for external-snapshotter v5.0.1:
- volumesnapshotcontents:patch
- volumesnapshotcontents/status:patch (already existed)
- volumesnapshots:patch
- volumesnapshots/status:patch

See https://github.com/openshift/csi-external-snapshotter/pull/66
/cc @openshift/storage 