### PR TITLE
Bug 2047025: Add "patch" permissions to Alibaba CSI driver operator

### DIFF
--- a/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
+++ b/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
@@ -225,6 +225,7 @@ rules:
   - watch
   - update
   - delete
+  - patch
 - apiGroups:
   - snapshot.storage.k8s.io
   resources:
@@ -234,6 +235,13 @@ rules:
   - list
   - watch
   - update
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots/status
+  verbs:
+  - patch
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
They're required by the new external-snapshotter sidecar.

cc @openshift/storage 