### PR TITLE
Add missing ibm cloud annotations to prometheus rbac

### DIFF
--- a/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_cluster-storage-operator_01_prometheusrbac.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prometheus
   namespace: openshift-cluster-storage-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -26,6 +27,7 @@ metadata:
   name: prometheus
   namespace: openshift-cluster-storage-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:


### PR DESCRIPTION
Currently, the servicemonitor but not the rbac is deployed which breaks
the scraping.