### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -105,6 +105,11 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
@@ -113,7 +118,10 @@ spec:
       securityContext:
         fsGroup: 10400
         runAsGroup: 10400
+        runAsNonRoot: true
         runAsUser: 10400
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: cluster-storage-operator
       tolerations:
       - effect: NoSchedule

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -37,7 +37,10 @@ spec:
       securityContext:
         fsGroup: 10400
         runAsGroup: 10400
+        runAsNonRoot: true
         runAsUser: 10400
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: cluster-storage-operator
           image: quay.io/openshift/origin-cluster-storage-operator:latest
@@ -126,6 +129,11 @@ spec:
             requests:
               cpu: 10m
               memory: 20Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
             - mountPath: /var/run/secrets/serving-cert
               name: cluster-storage-operator-serving-cert


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-cluster-storage-operator/deployments/cluster-storage-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"cluster-storage-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted c
apabilities (container \"cluster-storage-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"cluster-storage-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or co
ntainer \"cluster-storage-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 