### PR TITLE
Bug 2078625: Fix RelatedObjects when an API is missing in the API server

### DIFF
--- a/pkg/csoclients/csoclients.go
+++ b/pkg/csoclients/csoclients.go
@@ -1,11 +1,15 @@
 package csoclients
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
+	"time"
+
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"time"
 
 	cfgclientset "github.com/openshift/client-go/config/clientset/versioned"
 	cfginformers "github.com/openshift/client-go/config/informers/externalversions"
@@ -16,10 +20,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	prominformer "github.com/prometheus-operator/prometheus-operator/pkg/client/informers/externalversions"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
-	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 )
 
 type Clients struct {
@@ -54,7 +54,7 @@ type Clients struct {
 	DynamicClient dynamic.Interface
 
 	// Rest Mapper for mapping GVK to GVR
-	RestMapper       meta.RESTMapper
+	RestMapper       *restmapper.DeferredDiscoveryRESTMapper
 	CategoryExpander restmapper.CategoryExpander
 }
 

--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -20,8 +20,11 @@ import (
 	"github.com/openshift/library-go/pkg/operator/status"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	storagelister "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2"
 )
 
@@ -46,6 +49,7 @@ type CSIDriverStarterController struct {
 	infraLister       openshiftv1.InfrastructureLister
 	featureGateLister openshiftv1.FeatureGateLister
 	csiDriverLister   storagelister.CSIDriverLister
+	restMapper        *restmapper.DeferredDiscoveryRESTMapper
 	versionGetter     status.VersionGetter
 	targetVersion     string
 	eventRecorder     events.Recorder
@@ -77,6 +81,7 @@ func NewCSIDriverStarterController(
 		infraLister:       clients.ConfigInformers.Config().V1().Infrastructures().Lister(),
 		featureGateLister: clients.ConfigInformers.Config().V1().FeatureGates().Lister(),
 		csiDriverLister:   clients.KubeInformers.InformersFor("").Storage().V1().CSIDrivers().Lister(),
+		restMapper:        clients.RestMapper,
 		versionGetter:     versionGetter,
 		targetVersion:     targetVersion,
 		eventRecorder:     eventRecorder.WithComponentSuffix("CSIDriverStarter"),
@@ -158,6 +163,10 @@ func (c *CSIDriverStarterController) sync(ctx context.Context, syncCtx factory.S
 			// add static assets
 			objs, err := ctrl.ctrlRelatedObjects.RelatedObjects()
 			if err != nil {
+				if isNoMatchError(err) {
+					// RESTMapper NoResourceMatch / NoKindMatch errors are cached. Reset the cache to get fresh results on the next sync.
+					c.restMapper.Reset()
+				}
 				return err
 			}
 			relatedObjects = append(relatedObjects, objs...)
@@ -305,4 +314,19 @@ func isUnsupportedCSIDriverRunning(cfg csioperatorclient.CSIOperatorConfig, csiD
 
 func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
 	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
+}
+
+func isNoMatchError(err error) bool {
+	// ctrlRelatedObjects.RelatedObjects() may return aggregated errors, process that
+	if agg, ok := err.(utilerrors.Aggregate); ok {
+		errs := agg.Errors()
+		for _, err := range errs {
+			if meta.IsNoMatchError(err) {
+				return true
+			}
+		}
+		return false
+	}
+
+	return meta.IsNoMatchError(err)
 }


### PR DESCRIPTION
This is a 4.9 backport of https://github.com/openshift/cluster-storage-operator/pull/215:

```
When starting a CSI driver operator and discovering its dependencies / RelatedObjects, some APIs may be temporarily missing in the API server.

RESTMapper is caching the error responses, so make sure to refresh the cache in the next sync.
```
CC @openshift/storage 