### PR TITLE
Bug 2077050: Revert "OCP should default to pd-ssd disk type on GCP"

### DIFF
--- a/assets/storageclasses/gcp.yaml
+++ b/assets/storageclasses/gcp.yaml
@@ -6,7 +6,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/gce-pd
 parameters:
-  type: pd-ssd
+  type: pd-standard
   replication-type: none
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true


### PR DESCRIPTION
Reverts openshift/cluster-storage-operator#273. Clean revert.

GCP upgrade jobs are failing since this was merged with:

```
{Failed to upgrade storage, operator was not available (DefaultStorageClassController_SyncError): DefaultStorageClassControllerAvailable: StorageClass.storage.k8s.io "standard" is invalid: parameters: Forbidden: updates to parameters are forbidden.  Failed to upgrade storage, operator was not available (DefaultStorageClassController_SyncError): DefaultStorageClassControllerAvailable: StorageClass.storage.k8s.io "standard" is invalid: parameters: Forbidden: updates to parameters are forbidden.}
```

Example run https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.11-e2e-gcp-upgrade/1525003893585481728