### PR TITLE
Revert "Install shared resource csi driver webhook alongside the shared resource csi driver"

### DIFF
--- a/assets/csidriveroperators/shared-resource/09_deployment.yaml
+++ b/assets/csidriveroperators/shared-resource/09_deployment.yaml
@@ -25,8 +25,6 @@ spec:
           value: ${DRIVER_IMAGE}
         - name: NODE_DRIVER_REGISTRAR_IMAGE
           value: ${NODE_DRIVER_REGISTRAR_IMAGE}
-        - name: WEBHOOK_IMAGE
-          value: ${WEBHOOK_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -85,8 +85,6 @@ spec:
           value: quay.io/openshift/origin-csi-driver-shared-resource-operator:latest
         - name: SHARED_RESOURCE_DRIVER_IMAGE
           value: quay.io/openshift/origin-csi-driver-shared-resource:latest
-        - name: SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE
-          value: quay.io/openshift/origin-csi-driver-shared-resource-webhook:latest
         - name: ALIBABA_DISK_DRIVER_OPERATOR_IMAGE
           value: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
         - name: ALIBABA_CLOUD_DRIVER_IMAGE

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -115,8 +115,6 @@ spec:
             value: quay.io/openshift/origin-csi-driver-shared-resource-operator:latest
           - name: SHARED_RESOURCE_DRIVER_IMAGE
             value: quay.io/openshift/origin-csi-driver-shared-resource:latest
-          - name: SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE
-            value: quay.io/openshift/origin-csi-driver-shared-resource-webhook:latest
           - name: ALIBABA_DISK_DRIVER_OPERATOR_IMAGE
             value: quay.io/openshift/origin-alibaba-disk-csi-driver-operator:latest
           - name: ALIBABA_CLOUD_DRIVER_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -122,10 +122,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-csi-driver-shared-resource:latest
-  - name: csi-driver-shared-resource-webhook
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-csi-driver-shared-resource-webhook:latest
   - name: alibaba-disk-csi-driver-operator
     from:
       kind: DockerImage

--- a/pkg/operator/csidriveroperator/csioperatorclient/shared-resource.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/shared-resource.go
@@ -9,14 +9,12 @@ const (
 	SharedResourceDriverName             = "csi.sharedresource.openshift.io"
 	envSharedResourceDriverOperatorImage = "SHARED_RESOURCE_DRIVER_OPERATOR_IMAGE"
 	envSharedResourceDriverImage         = "SHARED_RESOURCE_DRIVER_IMAGE"
-	envSharedResourceDriverWebhookImage  = "SHARED_RESOURCE_DRIVER_WEBHOOK_IMAGE"
 )
 
 func GetSharedResourceCSIOperatorConfig() CSIOperatorConfig {
 	pairs := []string{
 		"${OPERATOR_IMAGE}", os.Getenv(envSharedResourceDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envSharedResourceDriverImage),
-		"${WEBHOOK_IMAGE}", os.Getenv(envSharedResourceDriverWebhookImage),
 	}
 
 	return CSIOperatorConfig{


### PR DESCRIPTION
This reverts commit 0c2757fb0652f78fa5d4c0a4fe343c659404db8c.

The commit in question has broken payload builds with the following
error:

error: failed to push image registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-05-16-100212: unable to upload new layer (0): Patch "https://registry.ci.openshift.org/v2/ocp/release/blobs/uploads/2b297c25-20a4-4811-b97c-bab3bafbf49d?_state=yap-S-67RRqpo0ZcQWfHZz84OreAAOIooCrJFbuNqod7Ik5hbWUiOiJvY3AvcmVsZWFzZSIsIlVVSUQiOiIyYjI5N2MyNS0yMGE0LTQ4MTEtYjk3Yy1iYWIzYmFmYmY0OWQiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjItMDUtMTZUMTA6MTA6NTAuOTc5NjQxNjkyWiJ9": operator "cluster-storage-operator" contained an invalid image-references file: no input image tag named "csi-driver-shared-resource-webhook"

See: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.11.0-0.nightly/release/4.11.0-0.nightly-2022-05-16-100212


Per TRT policy we are asked to revert breaking changes as quickly as possible to get payloads flowing again, apologies for any inconvenience. We ask that to re-introduce, you revert *this* PR, and layer an additional separate commit on top that addresses the problem. However in this case that may not be applicable as I suspect you need to fix something in the ART pipelines to get your new image tag, then reintroduce this change as is?

Will file a bug for tracking purposes to make sure the change doesn't get lost.
