### PR TITLE
Bug 2088533: remove unused '-v' for shared resource operator as part of klogv2/openshift api/ k8s bump

### DIFF
--- a/assets/csidriveroperators/shared-resource/09_deployment.yaml
+++ b/assets/csidriveroperators/shared-resource/09_deployment.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
       - args:
         - start
-        - -v=${LOG_LEVEL}
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}


### PR DESCRIPTION
After the go.mod bumps in https://github.com/openshift/csi-driver-shared-resource-operator/pull/48 we now hit klog v2 pain on startup:

```
2022-05-23T23:10:05.349862146Z Error: unknown shorthand flag: 'v' in -v=2
2022-05-23T23:10:05.350357211Z Usage:
2022-05-23T23:10:05.350357211Z   shared-resources-operator start [flags]
2022-05-23T23:10:05.350357211Z 
2022-05-23T23:10:05.350357211Z Flags:
2022-05-23T23:10:05.350357211Z       --config string                    Location of the master configuration file to run from.
2022-05-23T23:10:05.350357211Z   -h, --help                             help for start
2022-05-23T23:10:05.350357211Z       --kubeconfig string                Location of the master configuration file to run from.
2022-05-23T23:10:05.350357211Z       --listen string                    The ip:port to serve on.
2022-05-23T23:10:05.350357211Z       --namespace string                 Namespace where the controller is running. Auto-detected if run in cluster.
2022-05-23T23:10:05.350357211Z       --terminate-on-files stringArray   A list of files. If one of them changes, the process will terminate.
2022-05-23T23:10:05.350357211Z 
2022-05-23T23:10:05.350357211Z unknown shorthand flag: 'v' in -v=2
```
Need to unblock.

I could not sort out how to reconcile https://github.com/kubernetes/klog#how-to-use-klog with library-go/cobra flags.  Types could not line up.

As it turns out, shared resource operator is only using `klog.Errorf` and `klog.Warningf` anyway, so it does not care about a verbosity setting.

/assign @jsafrane 
@deads2k @DennisPeriquet @coreydaley FYI