### PR TITLE
Bug 2077599: Fix vCenter / ESXi version alerts

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -70,7 +70,7 @@ spec:
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
         # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr: |
-          min_over_time(vsphere_esxi_version_total{api_version=~"^7\\.0\\.[0-1]|^6"}[5m]) > 0
+          min_over_time(vsphere_esxi_version_total{api_version=~"^7\\.0\\.[0-1].*|^6.*"}[5m]) > 0
         for: 10m
         labels:
           severity: info
@@ -83,7 +83,7 @@ spec:
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
         # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
         expr: |
-          min_over_time(vsphere_vcenter_info{api_version=~"^7\\.0\\.[0-1]|^6"}[5m]) > 0
+          min_over_time(vsphere_vcenter_info{api_version=~"^7\\.0\\.[0-1].*|^6.*"}[5m]) > 0
         for: 10m
         labels:
           severity: info


### PR DESCRIPTION
The alerting regular expression must match the whole label from `^` to `$`, hence add `.*` at the end.