### PR TITLE
Bug 2101645: DefaultStorageClassController reports fake message on azure and openstack

### DIFF
--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -196,6 +196,10 @@ func newStorageClassForCluster(infrastructure *configv1.Infrastructure) (*storag
 		storageClassFile = "storageclasses/gcp.yaml"
 	case configv1.VSpherePlatformType:
 		storageClassFile = "storageclasses/vsphere.yaml"
+	case configv1.AzurePlatformType:
+		return nil, supportedByCSIError
+	case configv1.OpenStackPlatformType:
+		return nil, supportedByCSIError
 	case configv1.OvirtPlatformType:
 		return nil, supportedByCSIError
 	default:

--- a/pkg/operator/defaultstorageclass/controller_test.go
+++ b/pkg/operator/defaultstorageclass/controller_test.go
@@ -243,7 +243,7 @@ func TestSync(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			// azurestackhub is not recognized by sync as a valid platform
+			// The controller syncs fine when azurestackhub is used and does not create a storage class
 			name: "azurestackhub",
 			initialObjects: testObjects{
 				storage:        getCR(),
@@ -252,7 +252,7 @@ func TestSync(t *testing.T) {
 			expectedObjects: testObjects{
 				storage: getCR(
 					withFalseConditions(conditionsPrefix+opv1.OperatorStatusTypeProgressing),
-					withTrueConditions(conditionsPrefix+"Disabled", conditionsPrefix+opv1.OperatorStatusTypeAvailable),
+					withTrueConditions(conditionsPrefix+opv1.OperatorStatusTypeAvailable),
 				),
 			},
 			expectErr: false,


### PR DESCRIPTION
Letting newStorageClassForCluster() default to unsupportedPlatformError is not appropriate because later in sync this results in reporting `"No default StorageClass for this platform"`. Instead we should report this message for Azure and OpenStack:

 `"StorageClass provided by supplied CSI Driver instead of the cluster-storage-operator"`