### PR TITLE
Bug 2112237: correct sc error messages for ibm and alibaba platforms

### DIFF
--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -196,7 +196,11 @@ func newStorageClassForCluster(infrastructure *configv1.Infrastructure) (*storag
 		storageClassFile = "storageclasses/gcp.yaml"
 	case configv1.VSpherePlatformType:
 		storageClassFile = "storageclasses/vsphere.yaml"
+	case configv1.AlibabaCloudPlatformType:
+		return nil, supportedByCSIError
 	case configv1.AzurePlatformType:
+		return nil, supportedByCSIError
+	case configv1.IBMCloudPlatformType:
 		return nil, supportedByCSIError
 	case configv1.OpenStackPlatformType:
 		return nil, supportedByCSIError


### PR DESCRIPTION
Fix message for IBM and Alibaba cloud so a ClusterOperator condition reports:
`"StorageClass provided by supplied CSI Driver instead of the cluster-storage-operator"`

instead of:
`"No default StorageClass for this platform"`

For Nutanix and any other platforms we don't support the message should still be:
`"No default StorageClass for this platform"`


https://bugzilla.redhat.com/show_bug.cgi?id=2112237
/cc @openshift/storage