### PR TITLE
OCPBUGS-946: Resource csi.storage.k8s.io/csinodeinfos added to powervs-block-csi-d river-operator-clusterrole

### DIFF
--- a/assets/csidriveroperators/powervs-block/04_clusterrole.yaml
+++ b/assets/csidriveroperators/powervs-block/04_clusterrole.yaml
@@ -268,6 +268,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csinodeinfos
+  verbs:
+  - get
+  - list
+  - watch
 # Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
 - apiGroups:
   - "authentication.k8s.io"


### PR DESCRIPTION
Resource csi.storage.k8s.io/csinodeinfos added to powervs-block-csi-d river-operator-clusterrole.
Fixes the warnings in storage cluster operator - PowerVS CSI driver deployment.
Redhat bugzilla: https://issues.redhat.com/browse/OCPBUGS-946