### PR TITLE
Remove specific UID from cluster-storage-operator

### DIFF
--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -122,10 +122,7 @@ spec:
           name: cluster-storage-operator-serving-cert
       priorityClassName: system-cluster-critical
       securityContext:
-        fsGroup: 10400
-        runAsGroup: 10400
         runAsNonRoot: true
-        runAsUser: 10400
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -35,10 +35,7 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-storage-operator
       securityContext:
-        fsGroup: 10400
-        runAsGroup: 10400
         runAsNonRoot: true
-        runAsUser: 10400
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
OCP will assign its own UID to the Pod. This helps in HyperShift, where UIDs of different guest control planes should be different.