### PR TITLE
Bump go to 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-storage-operator
 COPY . .
 RUN make

--- a/pkg/operator/csidriveroperator/olmremovalcontroller.go
+++ b/pkg/operator/csidriveroperator/olmremovalcontroller.go
@@ -23,10 +23,11 @@ import (
 // This OLMOperatorRemovalController deletes pre-existing CSI driver installed by
 // OLM to new CSI driver namespace.
 // Steps performed:
-// 1. Remove old OLM Subscription and CSV. Remember the operator namespace
-//    (in Storage CR annotation), just in case the controller is restarted
-//    after Subscription removal.
-// 3. Remove the old CR (incl. force-removing all of its finalizers).
+//  1. Remove old OLM Subscription and CSV. Remember the operator namespace
+//     (in Storage CR annotation), just in case the controller is restarted
+//     after Subscription removal.
+//  3. Remove the old CR (incl. force-removing all of its finalizers).
+//
 // It produces following conditions:
 // <CSI driver name>OLMOperatorRemovalProgressing/Degraded: for status reporting.
 // <CSI driver name>OLMOperatorRemovalAvailable: to signal that the removal has been complete

--- a/pkg/operator/defaultstorageclass/controller.go
+++ b/pkg/operator/defaultstorageclass/controller.go
@@ -35,9 +35,9 @@ var supportedByCSIError = errors.New("only supported by a provided CSI Driver")
 // based on the underlying cloud (read from Infrastructure instance).
 // It produces following Conditions:
 // DefaultStorageClassControllerAvailable: the default storage class has been
-//    created.
+// created.
 // DefaultStorageClassControllerProgressing - the default storage class has
-//    not been created yet (typically on error).
+// not been created yet (typically on error).
 // DefaultStorageClassControllerDegraded - error creating the storage class.
 type Controller struct {
 	operatorClient     v1helpers.OperatorClient

--- a/pkg/operator/snapshotcrd/controller.go
+++ b/pkg/operator/snapshotcrd/controller.go
@@ -28,7 +28,7 @@ const (
 // and marks the cluster Upgradeable=false when they're found.
 // It produces following Conditions:
 // SnapshotCRDControllerUpgradeable: v1alpha1 VolumeSnapshot CRDs are not
-//    present.
+// present.
 // SnapshotCRDControllerDegraded - error checking for CRDs.
 type Controller struct {
 	operatorClient v1helpers.OperatorClient


### PR DESCRIPTION
Based on https://github.com/openshift/cluster-storage-operator/pull/320, bump go to 1.19 and fix gofmt.

@openshift/storage 