### PR TITLE
OCPBUGS-2880: Fix panic on empty featureGate.spec.customNoUpgrade

### DIFF
--- a/pkg/operator/csidriveroperator/driverstarter.go
+++ b/pkg/operator/csidriveroperator/driverstarter.go
@@ -290,7 +290,11 @@ func getEnabledFeatures(fg *configv1.FeatureGate) []string {
 		return nil
 	}
 	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade {
-		return fg.Spec.CustomNoUpgrade.Enabled
+		if fg.Spec.CustomNoUpgrade != nil {
+			return fg.Spec.CustomNoUpgrade.Enabled
+		}
+		// User wants CustomNoUpgrade, but did not set any feature gate.
+		return nil
 	}
 	gates := configv1.FeatureSets[fg.Spec.FeatureSet]
 	if gates == nil {

--- a/pkg/operator/csidriveroperator/driverstarter_test.go
+++ b/pkg/operator/csidriveroperator/driverstarter_test.go
@@ -134,6 +134,58 @@ func TestShouldRunController(t *testing.T) {
 			false,
 			false,
 		},
+		{
+			"tech preview Shared Resource driver with positive custom featureGate",
+			v1.AWSPlatformType,
+			customSet("SomeOtherFeatureGate", "CSIDriverSharedResource", "YetAnotherGate"),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "csi.sharedresource.openshift.io",
+				Platform:           v1.AWSPlatformType,
+				RequireFeatureGate: "CSIDriverSharedResource",
+			},
+			true,
+			false,
+		},
+		{
+			"tech preview Shared Resource driver with negative custom featureGate",
+			v1.AWSPlatformType,
+			customSet("SomeOtherFeatureGate"),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "csi.sharedresource.openshift.io",
+				Platform:           v1.AWSPlatformType,
+				RequireFeatureGate: "CSIDriverSharedResource",
+			},
+			false,
+			false,
+		},
+		{
+			"tech preview Shared Resource driver with empty custom featureGate",
+			v1.AWSPlatformType,
+			customSet(),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "csi.sharedresource.openshift.io",
+				Platform:           v1.AWSPlatformType,
+				RequireFeatureGate: "CSIDriverSharedResource",
+			},
+			false,
+			false,
+		},
+		{
+			"tech preview Shared Resource driver with nil custom featureGate",
+			v1.AWSPlatformType,
+			customNilSet(),
+			nil,
+			csioperatorclient.CSIOperatorConfig{
+				CSIDriverName:      "csi.sharedresource.openshift.io",
+				Platform:           v1.AWSPlatformType,
+				RequireFeatureGate: "CSIDriverSharedResource",
+			},
+			false,
+			false,
+		},
 	}
 
 	for _, test := range tests {
@@ -176,6 +228,17 @@ func customSet(gates ...string) *v1.FeatureGate {
 				CustomNoUpgrade: &v1.CustomFeatureGates{
 					Enabled: gates,
 				},
+			},
+		},
+	}
+}
+
+func customNilSet() *v1.FeatureGate {
+	return &v1.FeatureGate{
+		Spec: v1.FeatureGateSpec{
+			FeatureGateSelection: v1.FeatureGateSelection{
+				FeatureSet:      v1.CustomNoUpgrade,
+				CustomNoUpgrade: nil,
 			},
 		},
 	}


### PR DESCRIPTION
Don't panic when user sets `fg.Spec.FeatureSet`, but leaves `fg.Spec.CustomNoUpgrade` nil or empty. It is a weird configuration, where user wants custom flags but does not set any, but the operator should not crash.

cc @openshift/storage 