### PR TITLE
OCPBUGS-3312: Add capability annotation to openshift-cluster-storage-operator namespace

### DIFF
--- a/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
+++ b/manifests/0000_49_cluster-storage-operator_01_operator_namespace.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
+    capability.openshift.io/name: Storage+CSISnapshot
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-cluster-storage-operator


### PR DESCRIPTION
The namespace should only be created when both Storage and CSISnapshot capabilities are enabled.

CC @openshift/storage 