### PR TITLE
OCPBUGS-4508:User real node name in failing mount alerts

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -42,5 +42,5 @@ spec:
           description: |
             Failing storage operation "{{ $labels.operation_name }}" of volume plugin {{ $labels.volume_plugin }} was preventing Pods on node {{ $labels.node }}
             from starting for past 5 minutes.
-            Please investigate Pods that are "ContainerCreating" on the node: "oc get pod --field-selector=spec.nodeName=ip-10-0-130-168.ec2.internal --all-namespaces | grep ContainerCreating".
+            Please investigate Pods that are "ContainerCreating" on the node: "oc get pod --field-selector=spec.nodeName={{ $labels.node }} --all-namespaces | grep ContainerCreating".
             Events of the Pods should contain exact error message: "oc describe pod -n <pod namespace> <pod name>".


### PR DESCRIPTION
Fixes OCPBUGS-4508

