### PR TITLE
OCPBUGS-7300: hypershift: remove inject-proxy annotation from aws-ebs-csi-driver-operator deployment

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/09_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/09_deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   name: aws-ebs-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
-  annotations:
-    config.openshift.io/inject-proxy: aws-ebs-csi-driver-operator
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
`aws-ebs-csi-driver-operator` runs in the mgmt cluster and does not need to be configured with the guest cluster proxy

hypershift proxy conformance test currently fails because the `storage` CO never becomes `Available`

https://k8s-testgrid.appspot.com/redhat-hypershift#4.13-conformance-aws-ovn-proxy

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-main-periodics-4.13-conformance-aws-ovn-proxy/1623517300822904832/artifacts/conformance-aws-ovn-proxy/dump/artifacts/namespaces/clusters-70d2a995b41e8ac652b7/core/pods/logs/aws-ebs-csi-driver-operator-84df7c667b-7mlxq-aws-ebs-csi-driver-operator-previous.log