### PR TITLE
OCPBUGS-6992: Add UID to CSO Pod to be able to run with custom SCCs

### DIFF
--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -125,6 +125,7 @@ spec:
           name: guest-kubeconfig
       securityContext:
         runAsNonRoot: true
+        runAsUser: 11411
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: cluster-storage-operator

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -127,6 +127,7 @@ spec:
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
+        runAsUser: 11411
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -37,6 +37,10 @@ spec:
       serviceAccountName: cluster-storage-operator
       securityContext:
         runAsNonRoot: true
+        # Force a specific UID, just in case this Pod matches a custom SCC with "runAsUser: type: runAsNonRoot".
+        # The UID value was chosen by a fair `echo $RANDOM` call.
+        # TODO: remove cluster-admin from the operator, then a specific UID won't be needed.
+        runAsUser: 11411
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
When there is a custom SCC with `runAsUser: type: runAsNonRoot`, CSO pod can match it. Then the Pod must have a non-root UID assigned to be able to run.

This moves the CSO Pods from `restricted-v2` SCC to `nonroot-v2` SCC in the default OCP installation.

This is a workaround for CSO using cluster-admin role, which can allow CSO to use any SCC. If CSO had specific role(s) to use only few selected SCCs, we could remove this patch.