### PR TITLE
OCPBUGS-5410: add ReEncrypt KMS permissions

### DIFF
--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -37,6 +37,7 @@ spec:
       resource: "*"
     - effect: Allow
       action:
+      - 'kms:ReEncrypt*'
       - kms:Decrypt
       - kms:Encrypt
       - kms:GenerateDataKey


### PR DESCRIPTION
When a snapshot is shared in AWS the KMS key needs to be shared as well with a set of permissions documented here:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-modifying-snapshot-permissions.html#share-kms-key

Without the 'kms:ReEncrypt*' permissions restoring a PVC from an encrypted snapshot fails.