### PR TITLE
OCPBUGS-8328: assets: csi: hypershift: add pull-secret to aws-ebs-csi-driver-operator ServiceAccount

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/02_sa.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/02_sa.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: aws-ebs-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
+imagePullSecrets:
+- name: pull-secret


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-8328