### PR TITLE
 OCPBUGS-8683: Add management workloads annotations

### DIFF
--- a/assets/vsphere_problem_detector/07_deployment.yaml
+++ b/assets/vsphere_problem_detector/07_deployment.yaml
@@ -13,6 +13,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: vsphere-problem-detector-operator
     spec:


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (https://github.com/openshift/enhancements/pull/703).