### PR TITLE
OCPBUGS-11112: Add missing workload label to openshift-manila-csi-driver NS

### DIFF
--- a/assets/csidriveroperators/manila/01_namespace.yaml
+++ b/assets/csidriveroperators/manila/01_namespace.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
Tag the `openshift-manila-csi-driver` namespace with the proper
`workload.openshift.io/allowed` label in order to support the Management
Workload Partitioning enhancement proposal [1].

[1] https://github.com/openshift/enhancements/blob/master/enhancements/workload-partitioning/management-workload-partitioning.md