### PR TITLE
OCPBUGS-11729: VSphereStorageDriver does not document the platform default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2
+	github.com/openshift/api v0.0.0-20230414095907-0540dde8186d
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
 	github.com/openshift/library-go v0.0.0-20230130121854-13dc1e57ef79

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2 h1:lpKBKpI8or60mSEEKrpS67cevp8XaW8vfmXSwCZXKd0=
-github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
+github.com/openshift/api v0.0.0-20230414095907-0540dde8186d h1:zLQfV5KWXt3zS+yp/16YcnJWG9hV7WoMUyXRLCuUzOI=
+github.com/openshift/api v0.0.0-20230414095907-0540dde8186d/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=

--- a/vendor/github.com/openshift/api/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -70,7 +70,7 @@ spec:
                   nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 vsphereStorageDriver:
-                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.'
+                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.'
                   type: string
                   enum:
                     - ""
@@ -79,6 +79,8 @@ spec:
                   x-kubernetes-validations:
                     - rule: oldSelf != "CSIWithMigrationDriver" || self == "CSIWithMigrationDriver"
                       message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
+                    - rule: self != "LegacyDeprecatedInTreeDriver"
+                      message: VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver
               x-kubernetes-validations:
                 - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'
                   message: VSphereStorageDriver is required once set

--- a/vendor/github.com/openshift/api/operator/v1/stable.storage.testsuite.yaml
+++ b/vendor/github.com/openshift/api/operator/v1/stable.storage.testsuite.yaml
@@ -14,6 +14,28 @@ tests:
       spec:
         logLevel: Normal
         operatorLogLevel: Normal
+  onCreate:
+  - name: Should allow creating Storage with vsphere migration enabled
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  onCreate:
+  - name: Should not allow creating Storage with vsphere migration disabled
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expectedError: "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
   onUpdate:
   - name: Should allow enabling CSI migration for vSphere
     initial: |
@@ -32,7 +54,7 @@ tests:
         vsphereStorageDriver: CSIWithMigrationDriver
         logLevel: Normal
         operatorLogLevel: Normal
-  - name: Should allow disabling CSI migration for vSphere
+  - name: Should not allow disabling CSI migration for vSphere
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Storage
@@ -42,31 +64,7 @@ tests:
       kind: Storage
       spec:
         vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-        logLevel: Normal
-        operatorLogLevel: Normal
-  - name: Should allow changing LegacyDeprecatedInTreeDriver to CSIWithMigrationDriver
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    updated: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: CSIWithMigrationDriver
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: CSIWithMigrationDriver
-        logLevel: Normal
-        operatorLogLevel: Normal
+    expectedError: "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
   - name: Should not allow changing CSIWithMigrationDriver to LegacyDeprecatedInTreeDriver
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -102,21 +100,3 @@ tests:
       kind: Storage
       spec: {}
     expectedError: "VSphereStorageDriver is required once set"
-  - name: Should allow changing LegacyDeprecatedInTreeDriver to empty string
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    updated: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: ""
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: ""
-        logLevel: Normal
-        operatorLogLevel: Normal

--- a/vendor/github.com/openshift/api/operator/v1/types_storage.go
+++ b/vendor/github.com/openshift/api/operator/v1/types_storage.go
@@ -47,8 +47,10 @@ type StorageSpec struct {
 	// Once this field is set to CSIWithMigrationDriver, it can not be changed.
 	// If this is empty, the platform will choose a good default,
 	// which may change over time without notice.
+	// The current default is CSIWithMigrationDriver and may not be changed.
 	// DEPRECATED: This field will be removed in a future release.
 	// +kubebuilder:validation:XValidation:rule="oldSelf != \"CSIWithMigrationDriver\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+	// +kubebuilder:validation:XValidation:rule="self != \"LegacyDeprecatedInTreeDriver\"",message="VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
 	// +optional
 	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`
 }

--- a/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1654,7 +1654,7 @@ func (StorageList) SwaggerDoc() map[string]string {
 
 var map_StorageSpec = map[string]string{
 	"":                     "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
-	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.",
 }
 
 func (StorageSpec) SwaggerDoc() map[string]string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,7 +154,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20230406152840-ce21e3fe5da2
+# github.com/openshift/api v0.0.0-20230414095907-0540dde8186d
 ## explicit; go 1.19
 github.com/openshift/api
 github.com/openshift/api/apiserver


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11729
This PR bumps openshift/api to get the latest API change to the Storage CR in 4.14.
/cc @openshift/storage
