### PR TITLE
WIP: CCO-324: azure-disk: mount OIDC token and specify serviceAccountName

### DIFF
--- a/assets/csidriveroperators/azure-disk/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/08_deployment.yaml
@@ -52,6 +52,10 @@ spec:
           requests:
             memory: 50Mi
             cpu: 10m
+        volumeMounts:
+        - name: bound-sa-token
+          mountPath: /var/run/secrets/openshift/serviceaccount
+          readOnly: true
       priorityClassName: system-cluster-critical
       serviceAccountName: azure-disk-csi-driver-operator
       nodeSelector:
@@ -62,3 +66,10 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: "NoSchedule"
+      volumes:
+      - name: bound-sa-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              audience: openshift

--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -8,6 +8,8 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Storage
 spec:
+  serviceAccountNames:
+  - azure-disk-csi-driver-operator
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec


### PR DESCRIPTION
Mount the OIDC token into the `azure-disk-csi-driver-operator` and specify the `serviceAccountName` in the `azure-disk-csi-driver-operator` credentials request.

https://issues.redhat.com/browse/CCO-324