### PR TITLE
CCO-319: Add serviceAccountNames to azure-disk and azure-file credentials

### DIFF
--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -8,6 +8,9 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Storage
 spec:
+  serviceAccountNames:
+  - azure-disk-csi-driver-operator
+  - azure-disk-csi-driver-controller-sa
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -8,6 +8,10 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Storage
 spec:
+  serviceAccountNames:
+  - azure-file-csi-driver-operator
+  - azure-file-csi-driver-controller-sa
+  - azure-file-csi-driver-node-sa
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec


### PR DESCRIPTION
Add the necessary serviceAccountNames to the azure-disk-csi-driver-operator and azure-file-csi-driver-operator credentials requests to enable Azure workload identity tokens.