### PR TITLE
STOR-1167: Add permissions needed by fast snapshots to AWS CSI driver

### DIFF
--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -34,6 +34,8 @@ spec:
       - ec2:DescribeVolumesModifications
       - ec2:DetachVolume
       - ec2:ModifyVolume
+      - ec2:DescribeAvailabilityZones
+      - ec2:EnableFastSnapshotRestores
       resource: "*"
     - effect: Allow
       action:


### PR DESCRIPTION
As mentioned in upstream fast-restore docs: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/fast-snapshot-restores.md#prerequisites

@openshift/storage 