### PR TITLE
OCPBUGS-13187: Make vsphere-problem-detector alerts configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,10 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-require github.com/prometheus-operator/prometheus-operator/pkg/client v0.64.0
+require (
+	github.com/prometheus-operator/prometheus-operator/pkg/client v0.64.0
+	gopkg.in/yaml.v2 v2.4.0
+)
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
@@ -104,7 +107,6 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.27.1 // indirect
 	k8s.io/kms v0.27.1 // indirect

--- a/pkg/operator/vsphereproblemdetector/config.go
+++ b/pkg/operator/vsphereproblemdetector/config.go
@@ -1,0 +1,52 @@
+package vsphereproblemdetector
+
+import (
+	"fmt"
+
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+)
+
+type DetectorConfig struct {
+	AlertsDisabled bool `yaml:"alertsDisabled,omitempty"`
+}
+
+var (
+	defaultConfig = DetectorConfig{
+		// Alerts are enabled by default
+		AlertsDisabled: false,
+	}
+)
+
+const (
+	detectorConfigMapName = "vsphere-problem-detector"
+	configKey             = "config.yaml"
+)
+
+func ParseConfigMap(lister listerv1.ConfigMapLister) (*DetectorConfig, error) {
+	cm, err := lister.ConfigMaps(csoclients.OperatorNamespace).Get(detectorConfigMapName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Missing ConfigMap indicates default config
+			klog.V(4).Infof("Using default config, %s does not exist", detectorConfigMapName)
+			return &defaultConfig, nil
+		}
+		return nil, err
+	}
+
+	data, found := cm.Data[configKey]
+	if !found {
+		return nil, fmt.Errorf("invalid format of ConfigMap %s: expected key %s", detectorConfigMapName, configKey)
+	}
+
+	config := defaultConfig
+	err = yaml.UnmarshalStrict([]byte(data), &config)
+	if err != nil {
+		return nil, fmt.Errorf("invalid format of ConfigMap %s: %s", detectorConfigMapName, err)
+	}
+	klog.V(4).Infof("Parsed ConfigMap %s: %+v", detectorConfigMapName, config)
+	return &config, nil
+}

--- a/pkg/operator/vsphereproblemdetector/config_test.go
+++ b/pkg/operator/vsphereproblemdetector/config_test.go
@@ -1,0 +1,97 @@
+package vsphereproblemdetector
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func getCM(data map[string]string) *v1.ConfigMap {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      detectorConfigMapName,
+			Namespace: csoclients.OperatorNamespace,
+		},
+		Data: data,
+	}
+	return cm
+}
+
+func TestParseConfigMap(t *testing.T) {
+	tests := []struct {
+		name           string
+		configMap      *v1.ConfigMap
+		expectedConfig *DetectorConfig
+		expectError    bool
+	}{
+		{
+			name:           "non-existing ConfigMap",
+			configMap:      nil,
+			expectedConfig: &DetectorConfig{AlertsDisabled: false},
+			expectError:    false,
+		},
+		{
+			name:           "ConfigMap with empty data",
+			configMap:      getCM(map[string]string{}),
+			expectedConfig: nil,
+			expectError:    true,
+		},
+		{
+			name:           "ConfigMap with invalid key",
+			configMap:      getCM(map[string]string{"foo": "bar"}),
+			expectedConfig: nil,
+			expectError:    true,
+		},
+		{
+			name:           "ConfigMap with empty config yaml",
+			configMap:      getCM(map[string]string{configKey: ""}),
+			expectedConfig: &DetectorConfig{AlertsDisabled: false},
+			expectError:    false,
+		},
+		{
+			name:           "ConfigMap with valid config yaml, explicitly disabled",
+			configMap:      getCM(map[string]string{configKey: "alertsDisabled: true"}),
+			expectedConfig: &DetectorConfig{AlertsDisabled: true},
+			expectError:    false,
+		},
+		{
+			name:           "ConfigMap with valid config yaml, explicitly enabled",
+			configMap:      getCM(map[string]string{configKey: "alertsDisabled: false"}),
+			expectedConfig: &DetectorConfig{AlertsDisabled: false},
+			expectError:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var client kubernetes.Interface
+			if tt.configMap != nil {
+				client = fake.NewSimpleClientset(tt.configMap)
+			} else {
+				client = fake.NewSimpleClientset()
+			}
+			informerFactory := informers.NewSharedInformerFactory(client, time.Hour)
+			cmInformer := informerFactory.Core().V1().ConfigMaps()
+			if tt.configMap != nil {
+				cmInformer.Informer().GetIndexer().Add(tt.configMap)
+			}
+
+			got, err := ParseConfigMap(cmInformer.Lister())
+			if err != nil && !tt.expectError {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Errorf("expected error, got none")
+			}
+			if !reflect.DeepEqual(got, tt.expectedConfig) {
+				t.Errorf("unexpected config received, got = %v, want %v", got, tt.expectedConfig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Create/delete detector's PrometheusRule instances based on value of ConfigMap `vsphere-problem-detector`.

Example:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: vsphere-problem-detector
  namespace: openshift-cluster-storage-operator
data:
  config.yaml: |
    alertsDisabled: true
```

cc @openshift/storage 