### PR TITLE
OCPBUGS-14053: decrease severity for MultipleDefaultStorageClasses alert

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -18,7 +18,7 @@ spec:
         expr:  max_over_time(default_storage_class_count[5m]) > 1
         for: 10m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: "More than one default StorageClass detected."
           description: |


### PR DESCRIPTION
Since 4.13 volume provisioning won't fail any more when multiple defaults SCs are present because one is always picked: https://github.com/kubernetes/kubernetes/pull/110559/commits/f12325add3fbac8a2ce31cb12b4649c01d74f248

It no longer makes sense for this alert to be critical - lowering it's severity to warning.

cc @openshift/storage 