### PR TITLE
STOR-1065: Publish reduced snapshotter_role yaml

### DIFF
--- a/manifests/09_sidecar-reduced_snapshotter_role.yaml
+++ b/manifests/09_sidecar-reduced_snapshotter_role.yaml
@@ -1,0 +1,40 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-csi-reduced-snapshotter-role
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Storage
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents/status"]
+  verbs: ["update"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create", "list", "watch", "delete"]


### PR DESCRIPTION
The patch only publish new ClusterRole: `openshift-csi-reduced-snapshotter-role`. It is safe because nobody uses this ClusterRole yet.

This new role is requires for gcp-filestore cs driver operator. It cannot use `openshift-csi-main-snapshotter-role` because `ci/prow/operator-e2e-extended` failed with:
```
Jul 24 03:55:23.267 W ns/openshift-cluster-csi-drivers deployment/gcp-filestore-csi-driver-operator Failed to create ClusterRoleBinding.rbac.authorization.k8s.io/gcp-filestore-csi-main-snapshotter-binding: clusterrolebindings.rbac.authorization.k8s.io "gcp-filestore-csi-main-snapshotter-binding" is forbidden: user "system:serviceaccount:openshift-cluster-csi-drivers:gcp-filestore-csi-driver-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-cluster-csi-drivers" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:["snapshot.storage.k8s.io"], Resources:["volumesnapshotcontents/status"], Verbs:["patch"]} (42 times)
```
(https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_gcp-filestore-csi-driver-operator/44/pull-ci-openshift-gcp-filestore-csi-driver-operator-main-operator-e2e-extended/1683306971899367424)