### PR TITLE
STOR-1274: use granular permissons for Azure credential requests

### DIFF
--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -14,8 +14,15 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
+    permissions:
+      - 'Microsoft.Compute/disks/*'
+      - 'Microsoft.Compute/snapshots/*'
+      - 'Microsoft.Compute/virtualMachineScaleSets/*/read'
+      - 'Microsoft.Compute/virtualMachineScaleSets/read'
+      - 'Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write'
+      - 'Microsoft.Compute/virtualMachines/*/read'
+      - 'Microsoft.Compute/virtualMachines/write'
+      - 'Microsoft.Resources/subscriptions/resourceGroups/read'
   secretRef:
     name: azure-disk-credentials
     namespace: openshift-cluster-csi-drivers

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -15,8 +15,18 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
+    permissions:
+      - 'Microsoft.Network/networkSecurityGroups/join/action'
+      - 'Microsoft.Network/virtualNetworks/subnets/read'
+      - 'Microsoft.Network/virtualNetworks/subnets/write'
+      - 'Microsoft.Storage/storageAccounts/delete'
+      - 'Microsoft.Storage/storageAccounts/fileServices/read'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/delete'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/read'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/write'
+      - 'Microsoft.Storage/storageAccounts/listKeys/action'
+      - 'Microsoft.Storage/storageAccounts/read'
+      - 'Microsoft.Storage/storageAccounts/write'
   secretRef:
     name: azure-file-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
Set granular permissions according to upstream documentation:

Azure Disk: https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
Azure File: https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/master/docs/driver-parameters.md

Also one extra permission needed was discovered by CI tests and added for Azure Disk: `'Microsoft.Compute/virtualMachines/write'`

And a few more discovered by QE tests: 
`'Microsoft.Network/networkSecurityGroups/join/action'`
`'Microsoft.Network/virtualNetworks/subnets/read'`
`'Microsoft.Network/virtualNetworks/subnets/write'`