### PR TITLE
Remove "get" verb from "events" resource of RBAC for provisioner sidecar

### DIFF
--- a/manifests/09_sidecar-main_provisioner_role.yaml
+++ b/manifests/09_sidecar-main_provisioner_role.yaml
@@ -19,7 +19,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Let's keep `manifests/09_sidecar-main_provisioner_role.yaml` in sync with upstream (https://github.com/openshift/csi-external-provisioner/blob/master/deploy/kubernetes/rbac.yaml)

See discussion at https://github.com/openshift/aws-ebs-csi-driver-operator/pull/245.