### PR TITLE
OCPBUGS-17356: Fix PodStartupStorageOperationsFailing alert

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -33,7 +33,7 @@ spec:
         # Focus on attach and mount operations - they have the same diagnostic steps and are the most common.
         expr: |
           increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) > 0
-          and on() increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m]) == 0
+          and ignoring(status) increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m]) == 0
         for: 5m
         labels:
           severity: info


### PR DESCRIPTION
Use `ignoring(status)` to match *only* rows that have *all* the same labels except for `status`.

`on()` would match a failing volume plugin with *any* other volume plugin / node that has not succeeded in past 5 minutes, e.g. with HostPath that had no activity (= zero successes) in the past 5 minutes.

@openshift/storage 