### PR TITLE
STOR-1432: hypershift: add independent refs for AWS EBS driver controller images

### DIFF
--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -104,6 +104,10 @@ spec:
           value: quay.io/openshift/origin-powervs-block-csi-driver:latest
         - name: HYPERSHIFT_IMAGE
           value: quay.io/openshift/origin-control-plane:latest
+        - name: AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+        - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-csi-livenessprobe:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest
         imagePullPolicy: IfNotPresent
         name: cluster-storage-operator

--- a/profile-patches/hypershift/10_deployment.yaml-patch
+++ b/profile-patches/hypershift/10_deployment.yaml-patch
@@ -36,6 +36,16 @@
   value:
     name: HYPERSHIFT_IMAGE
     value: quay.io/openshift/origin-control-plane:latest
+- op: add
+  path: /spec/template/spec/containers/0/env/40
+  value:
+    name: AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE
+    value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
+- op: add
+  path: /spec/template/spec/containers/0/env/41
+  value:
+    name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
+    value: quay.io/openshift/origin-csi-livenessprobe:latest
 # Add cmdline args
 - op: add
   path: /spec/template/spec/containers/0/args/-


### PR DESCRIPTION
Need to update this first as the authoritative source for https://github.com/openshift/hypershift/blob/main/control-plane-operator/controllers/hostedcontrolplane/storage/assets/10_deployment-hypershift.yaml