### PR TITLE
STOR-1432: hypershift: pass through control plane images to AWS EBS CSI driver operator

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -46,6 +46,10 @@ spec:
         env:
           - name: HYPERSHIFT_IMAGE
             value: ${HYPERSHIFT_IMAGE}
+          - name: DRIVER_CONTROL_PLANE_IMAGE
+            value: ${DRIVER_CONTROL_PLANE_IMAGE}
+          - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
+            value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
         volumeMounts:
           - mountPath: /etc/guest-kubeconfig
             name: guest-kubeconfig

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -49,6 +49,10 @@ spec:
         env:
         - name: HYPERSHIFT_IMAGE
           value: ${HYPERSHIFT_IMAGE}
+        - name: DRIVER_CONTROL_PLANE_IMAGE
+          value: ${DRIVER_CONTROL_PLANE_IMAGE}
+        - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
+          value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
         - name: PROVISIONER_IMAGE

--- a/pkg/operator/csidriveroperator/csioperatorclient/aws.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/aws.go
@@ -11,12 +11,15 @@ const (
 	AWSEBSCSIDriverName          = "ebs.csi.aws.com"
 	envAWSEBSDriverOperatorImage = "AWS_EBS_DRIVER_OPERATOR_IMAGE"
 	envAWSEBSDriverImage         = "AWS_EBS_DRIVER_IMAGE"
+
+	envAWSEBSDriverControlPlaneImage = "AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE"
 )
 
 func GetAWSEBSCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 	pairs := []string{
 		"${OPERATOR_IMAGE}", os.Getenv(envAWSEBSDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envAWSEBSDriverImage),
+		"${DRIVER_CONTROL_PLANE_IMAGE}", os.Getenv(envAWSEBSDriverControlPlaneImage),
 	}
 
 	csiDriverConfig := CSIOperatorConfig{

--- a/pkg/operator/csidriveroperator/util.go
+++ b/pkg/operator/csidriveroperator/util.go
@@ -25,6 +25,8 @@ const (
 	envNodeDriverRegistrarImage = "NODE_DRIVER_REGISTRAR_IMAGE"
 	envLivenessProbeImage       = "LIVENESS_PROBE_IMAGE"
 	envKubeRBACProxyImage       = "KUBE_RBAC_PROXY_IMAGE"
+
+	envLivenessProbeControlPlaneImage = "LIVENESS_PROBE_CONTROL_PLANE_IMAGE"
 )
 
 var (
@@ -35,6 +37,7 @@ var (
 		"${SNAPSHOTTER_IMAGE}", os.Getenv(envSnapshotterImage),
 		"${NODE_DRIVER_REGISTRAR_IMAGE}", os.Getenv(envNodeDriverRegistrarImage),
 		"${LIVENESS_PROBE_IMAGE}", os.Getenv(envLivenessProbeImage),
+		"${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}", os.Getenv(envLivenessProbeControlPlaneImage),
 		"${KUBE_RBAC_PROXY_IMAGE}", os.Getenv(envKubeRBACProxyImage),
 	)
 )


### PR DESCRIPTION
continuing work of
* https://github.com/openshift/cluster-storage-operator/pull/392
* https://github.com/openshift/hypershift/pull/2882

with a follow on in https://github.com/openshift/aws-ebs-csi-driver-operator

https://github.com/openshift/aws-ebs-csi-driver-operator/pull/252