### PR TITLE
STOR-1446: Restart `vsphere-problem-detector-operator` Pods if `serving-cert` changed

### DIFF
--- a/assets/csidriveroperators/shared-resource/standalone/09_deployment.yaml
+++ b/assets/csidriveroperators/shared-resource/standalone/09_deployment.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
       - args:
         - start
+        - --terminate-on-files=/etc/secrets/tls.crt
+        - --terminate-on-files=/etc/secrets/tls.key
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}

--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - start
         - --listen=0.0.0.0:8445
         - -v=${LOG_LEVEL}
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}

--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -19,6 +19,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         command:
         - cluster-storage-operator

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -23,6 +23,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         command:
         - cluster-storage-operator
         - start

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -50,6 +50,8 @@ spec:
           args:
           - start
           - -v=2
+          - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+          - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
           ports:
           - containerPort: 8443
             name: metrics

--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
@@ -34,7 +34,8 @@ import (
 const (
 	infraConfigName                     = "cluster"
 	vSphereProblemDetectorOperatorImage = "VSPHERE_PROBLEM_DETECTOR_OPERATOR_IMAGE"
-	secretName                          = "vsphere-cloud-credentials"
+	cloudCredSecretName                 = "vsphere-cloud-credentials"
+	metricsCertSecretName               = "vsphere-problem-detector-serving-cert"
 	cloudConfigNamespace                = "openshift-config"
 )
 
@@ -153,7 +154,13 @@ func (c *VSphereProblemDetectorStarter) createVSphereProblemDetectorManager(
 		// Restart when credentials change to get a quick retest
 		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
 			csoclients.OperatorNamespace,
-			secretName,
+			cloudCredSecretName,
+			clients.KubeInformers.InformersFor(csoclients.OperatorNamespace).Core().V1().Secrets(),
+		),
+		// Restart when serving-cert changes
+		csidrivercontrollerservicecontroller.WithSecretHashAnnotationHook(
+			csoclients.OperatorNamespace,
+			metricsCertSecretName,
 			clients.KubeInformers.InformersFor(csoclients.OperatorNamespace).Core().V1().Secrets(),
 		),
 		// Restart when cloud config changes to get a quick retest


### PR DESCRIPTION
Adding `WithSecretHashAnnotationHook()` for `vsphere-problem-detector-serving-cert` ensures that new annotation is published in `vsphere-problem-detector-operator` deployment. This, in turn, leads to operator pods restart.

The second patch in this PR adds commnad-line option `--terminate-on-files` to operators denedent on `metrics-serving-cert`:

     * CSO operator itself (uses secret `cluster-storage-operator-serving-cert`)
     * vmware-vsphere operator (uses secret `vmware-vsphere-csi-driver-operator-metrics-serving-cert`)
     * shared-resource operator (uses secret `shared-resource-csi-driver-operator-metrics-serving-cert`)

Hence, if corresponding secrets change, the operators are restarted.

/cc @openshift/storage 