### PR TITLE
OCPBUGS-18132: Add patch for allowing configmap updates via clusterrole

### DIFF
--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   resourceNames:
   - extension-apiserver-authentication
   - vmware-vsphere-csi-driver-operator-lock
+  - admin-gates
   resources:
   - configmaps
   verbs:
@@ -309,8 +310,6 @@ rules:
   - get
   - list
   - watch
-  - patch
-  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -309,6 +309,8 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
Goes with https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/169

Fixes OCPBUGS-18132
