### PR TITLE
OCPBUGS-19073: Move KAS access label to right place

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aws-ebs-csi-driver-operator
-  labels:
-    hypershift.openshift.io/need-management-kas-access: true
 spec:
   template:
+    metadata:
+      labels:
+        hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:
         nodeAffinity:

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    hypershift.openshift.io/need-management-kas-access: "true"
   name: aws-ebs-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
 spec:
@@ -16,6 +14,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        hypershift.openshift.io/need-management-kas-access: "true"
         name: aws-ebs-csi-driver-operator
     spec:
       affinity:


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-19073