### PR TITLE
OCPBUGS-22443: manila: Add missing CSI_FSGROUP_POLICY env var

### DIFF
--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -45,6 +45,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: CSI_FSGROUP_POLICY
+          value: None
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: manila-csi-driver-operator


### PR DESCRIPTION
This was mistakenly introduced to the wrong set of manifests in a previous change to the Manila CSI Driver Operator [1]. Correct this mistake.

/cc @fmount

[1] https://github.com/openshift/csi-driver-manila-operator/commit/660bbb775b09eefc7df4ec9587b70d657f7d31ff

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
