### PR TITLE
Synchronise management of CA certs between Manila, Cinder

### DIFF
--- a/assets/csidriveroperators/manila/07_deployment.yaml
+++ b/assets/csidriveroperators/manila/07_deployment.yaml
@@ -50,9 +50,8 @@ spec:
         name: manila-csi-driver-operator
         volumeMounts:
         - name: cacert
-          mountPath: /etc/openstack-ca/
+          mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
         - name: cloud-credentials
-          # Create /etc/openstack/clouds.yaml
           mountPath: /etc/openstack/
         resources:
           requests:
@@ -70,10 +69,11 @@ spec:
         effect: "NoSchedule"
       volumes:
       - name: cacert
-        # Extract ca-bundle.pem to /usr/share/pki/ca-trust-source if present.
+        # If present, extract ca-bundle.pem to
+        # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
         # Let the pod start when the ConfigMap does not exist or the certificate
         # is not preset there. The certificate file will be created once the
-        # ConfigMap is created / the cerificate is added to it.
+        # ConfigMap is created / the certificate is added to it.
         configMap:
           name: cloud-provider-config
           items:
@@ -84,3 +84,6 @@ spec:
         secret:
           secretName: manila-cloud-credentials
           optional: false
+          items:
+            - key: clouds.yaml
+              path: clouds.yaml

--- a/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/07_deployment.yaml
@@ -45,13 +45,13 @@ spec:
               fieldPath: metadata.name
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
+        name: openstack-cinder-csi-driver-operator
         volumeMounts:
-        - name: secret-cinderplugin
+        - name: cloud-credentials
           mountPath: /etc/openstack
           readOnly: true
         - name: cacert
           mountPath: /etc/kubernetes/static-pod-resources/configmaps/cloud-config
-        name: openstack-cinder-csi-driver-operator
         resources:
           requests:
             cpu: 10m
@@ -67,21 +67,21 @@ spec:
         operator: Exists
         effect: "NoSchedule"
       volumes:
-      - name: secret-cinderplugin
-        secret:
-          secretName: openstack-cloud-credentials
-          items:
-            - key: clouds.yaml
-              path: clouds.yaml
       - name: cacert
         # If present, extract ca-bundle.pem to
         # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
         # Let the pod start when the ConfigMap does not exist or the certificate
         # is not preset there. The certificate file will be created once the
-        # ConfigMap is created / the cerificate is added to it.
+        # ConfigMap is created / the certificate is added to it.
         configMap:
           name: cloud-provider-config
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
           optional: true
+      - name: cloud-credentials
+        secret:
+          secretName: openstack-cloud-credentials
+          items:
+            - key: clouds.yaml
+              path: clouds.yaml


### PR DESCRIPTION
No need to be using different techniques for the same thing.

WIP while I figure out how to synchronise merging of this and https://github.com/openshift/csi-driver-manila-operator/pull/185 which is also required.
