### PR TITLE
STOR-1453: Grant permissions to access `apiserver` to CSI driver operators

### DIFF
--- a/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
+++ b/assets/csidriveroperators/alibaba-disk/05_clusterrole.yaml
@@ -283,6 +283,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/aws-ebs/base/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/base/05_clusterrole.yaml
@@ -273,6 +273,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -272,6 +272,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -272,6 +272,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/06_clusterrole.yaml
@@ -293,6 +293,7 @@ rules:
   - proxies
   - clusterversions
   - featuregates
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/azure-file/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/06_clusterrole.yaml
@@ -297,6 +297,7 @@ rules:
   - proxies
   - clusterversions
   - featuregates
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
+++ b/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
@@ -283,6 +283,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/ibm-vpc-block/06_clusterrole.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/06_clusterrole.yaml
@@ -283,6 +283,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/manila/05_clusterrole.yaml
+++ b/assets/csidriveroperators/manila/05_clusterrole.yaml
@@ -266,6 +266,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-cinder/05_clusterrole.yaml
@@ -280,6 +280,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/ovirt/05_clusterrole.yaml
+++ b/assets/csidriveroperators/ovirt/05_clusterrole.yaml
@@ -268,6 +268,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/powervs-block/hypershift/guest/04_clusterrole.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/guest/04_clusterrole.yaml
@@ -295,6 +295,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/powervs-block/standalone/04_clusterrole.yaml
+++ b/assets/csidriveroperators/powervs-block/standalone/04_clusterrole.yaml
@@ -295,6 +295,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list

--- a/assets/csidriveroperators/vsphere/06_clusterrole.yaml
+++ b/assets/csidriveroperators/vsphere/06_clusterrole.yaml
@@ -294,6 +294,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list


### PR DESCRIPTION
The operators need to get `spec.tlsSecurityProfile` from apiserver cluster to construct command-line options `--tls-cipher-suites` and `--tls-min-version` for kube RBAC proxy sidecars.