### PR TITLE
OCPBUGS-23120: [IBM ROKS] cluster-storage-operator does not set upgradeable=True

### DIFF
--- a/pkg/operator/csidriveroperator/driver_starter.go
+++ b/pkg/operator/csidriveroperator/driver_starter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
 	"github.com/openshift/library-go/pkg/operator/status"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -49,16 +50,17 @@ type driverInterface interface {
 }
 
 type driverStarterCommon struct {
-	commonClients   *csoclients.Clients
-	resyncInterval  time.Duration
-	infraLister     openshiftv1.InfrastructureLister
-	featureGates    featuregates.FeatureGate
-	csiDriverLister storagelister.CSIDriverLister
-	restMapper      *restmapper.DeferredDiscoveryRESTMapper
-	versionGetter   status.VersionGetter
-	targetVersion   string
-	eventRecorder   events.Recorder
-	controllers     []csiDriverControllerManager
+	commonClients     *csoclients.Clients
+	resyncInterval    time.Duration
+	infraLister       openshiftv1.InfrastructureLister
+	featureGates      featuregates.FeatureGate
+	csiDriverLister   storagelister.CSIDriverLister
+	restMapper        *restmapper.DeferredDiscoveryRESTMapper
+	versionGetter     status.VersionGetter
+	targetVersion     string
+	eventRecorder     events.Recorder
+	controllers       []csiDriverControllerManager
+	controllerStarted bool // true if at least one controller has started
 }
 
 type standAloneDriverStarter struct {
@@ -93,12 +95,13 @@ func initCommonStarterParams(
 	targetVersion string,
 	eventRecorder events.Recorder) driverStarterCommon {
 	c := driverStarterCommon{
-		commonClients:  client,
-		versionGetter:  versionGetter,
-		targetVersion:  targetVersion,
-		resyncInterval: resyncInterval,
-		featureGates:   featureGates,
-		eventRecorder:  eventRecorder.WithComponentSuffix("CSIDriverStarter"),
+		commonClients:     client,
+		versionGetter:     versionGetter,
+		targetVersion:     targetVersion,
+		resyncInterval:    resyncInterval,
+		featureGates:      featureGates,
+		eventRecorder:     eventRecorder.WithComponentSuffix("CSIDriverStarter"),
+		controllerStarted: false,
 	}
 	return c
 }
@@ -179,6 +182,18 @@ func (dsrc *driverStarterCommon) isOperatorInstalled(name string) (bool, error) 
 	return true, nil
 }
 
+func (dsrc *driverStarterCommon) setUpgradeableTrue(ctx context.Context) error {
+	conditionPrefix := "StorageOperator"
+	upgradeableCnt := operatorapi.OperatorCondition{
+		Type:   conditionPrefix + operatorapi.OperatorStatusTypeUpgradeable,
+		Status: operatorapi.ConditionTrue,
+	}
+	_, _, err := v1helpers.UpdateStatus(ctx, dsrc.commonClients.OperatorClient,
+		v1helpers.UpdateConditionFn(upgradeableCnt),
+	)
+	return err
+}
+
 func (dsrc *driverStarterCommon) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	klog.V(4).Infof("CSIDriverStarterController.Sync started")
 	defer klog.V(4).Infof("CSIDriverStarterController.Sync finished")
@@ -238,6 +253,16 @@ func (dsrc *driverStarterCommon) sync(ctx context.Context, syncCtx factory.SyncC
 			klog.V(2).Infof("Starting ControllerManager for %s", ctrl.operatorConfig.ConditionPrefix)
 			go ctrl.mgr.Start(ctx)
 			ctrl.running = true
+			dsrc.controllerStarted = true
+		}
+	}
+
+	// If no controller has started, then CSIDriverOperatorCRController
+	// will not run and we have to set Upgradeable=true right now.
+	if !dsrc.controllerStarted {
+		err := dsrc.setUpgradeableTrue(ctx)
+		if err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-23120

## Problem

The upgradeable condition used to be set by SnapshotCRDController, but that was removed in https://github.com/openshift/cluster-storage-operator/pull/385/commits/fa9af3aad65b9d0e9c618453825e4defeaad59ac

DefaultStorageClassController only sets upgradeable=True if [unsupportedPlatformError](https://github.com/openshift/cluster-storage-operator/blob/dbb1514dbf9923c56a4a198374cc59e45f9bc0cc/pkg/operator/defaultstorageclass/controller.go#L97-L100).
IBM VPC returns [supportedbyCSIError](https://github.com/openshift/cluster-storage-operator/blob/dbb1514dbf9923c56a4a198374cc59e45f9bc0cc/pkg/operator/defaultstorageclass/controller.go#L207) instead.
The current code assumes if supportedbyCSIError, then [csidriveroperator controller](https://github.com/openshift/cluster-storage-operator/blob/dbb1514dbf9923c56a4a198374cc59e45f9bc0cc/pkg/operator/csidriveroperator/crcontroller.go#L220-L223) will eventually set it.

The problem is if [shouldRunController](https://github.com/openshift/cluster-storage-operator/blob/dbb1514dbf9923c56a4a198374cc59e45f9bc0cc/pkg/operator/csidriveroperator/driver_starter.go#L336) returns false for a driver with supportedbyCSIError. Then csidriveroperator does not start and nothing will set the condition. shouldRunController always returns false for IBM ROKS because of this [StatusFilter](https://github.com/openshift/cluster-storage-operator/blob/dbb1514dbf9923c56a4a198374cc59e45f9bc0cc/pkg/operator/csidriveroperator/csioperatorclient/ibm-vpc-block.go#L17-L27).

## Solution

DefaultStorageClassController has no way to tell if shouldRunController will eventually return false. So in this PR, CSIDriverStarter sets the condition if no controller is started, because we know at that point no other controller will set the condition.

/cc @openshift/storage @jeffnowicki
