### PR TITLE
OCPBUGS-24027: forbidden access to resource on shared-resource-csi-driver-operator

### DIFF
--- a/assets/csidriveroperators/shared-resource/standalone/05_clusterrole.yaml
+++ b/assets/csidriveroperators/shared-resource/standalone/05_clusterrole.yaml
@@ -317,6 +317,7 @@ rules:
   resources:
   - infrastructures
   - proxies
+  - apiservers
   verbs:
   - get
   - list


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-24027
/cc @openshift/storage
