### PR TITLE
TRT-1376: Revert #410 "CCO-251: use granular permissions for gcp credentails request"

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -17,14 +17,12 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    # Required driver permissions: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/1a1f846c41c963e17b4757ce3beb0bf1e817d473/docs/kubernetes/user-guides/driver-install.md?plain=1#L17-L21
     predefinedRoles:
-      - "roles/compute.storageAdmin"
-      - "roles/iam.serviceAccountUser"
-    permissions:
-      - "compute.instances.get"
-      - "compute.instances.attachDisk"
-      - "compute.instances.detachDisk"
+      # FIXME: find a replacement for instanceAdmin, since the CSI driver
+      # only needs "compute.instances.[get|attachDisk|DetachDisk]"
+      - roles/compute.instanceAdmin
+      - roles/compute.storageAdmin
+      - roles/iam.serviceAccountUser
     # If set to true, don't check whether the requested
     # roles have the necessary services enabled
     skipServiceCheck: true


### PR DESCRIPTION

Reverts #410 ; tracked by [TRT-1376](https://issues.redhat.com//browse/TRT-1376)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR appears to have retriggered the limits we're hitting with GCP roles similar to earlier this week. We are reverting to buy the CCO team time to figure out what to do.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Suspect you'll need to work with CCO team to get clearance for when it's safe to re-merge this PR.
```

CC: @RomanBednar

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
