### PR TITLE
CCO-251: TRT-1376: un-revert #410 "CCO-251: use granular permissions for gcp credentails request"

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -17,12 +17,39 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    predefinedRoles:
-      # FIXME: find a replacement for instanceAdmin, since the CSI driver
-      # only needs "compute.instances.[get|attachDisk|DetachDisk]"
-      - roles/compute.instanceAdmin
-      - roles/compute.storageAdmin
-      - roles/iam.serviceAccountUser
+    # Required driver permissions: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/1a1f846c41c963e17b4757ce3beb0bf1e817d473/docs/kubernetes/user-guides/driver-install.md?plain=1#L17-L21
+    permissions:
+      - "compute.instances.get"
+      - "compute.instances.attachDisk"
+      - "compute.instances.detachDisk"
+      - "compute.diskTypes.*"
+      - "compute.disks.*"
+      - "compute.globalOperations.get"
+      - "compute.globalOperations.list"
+      - "compute.images.*"
+      - "compute.instanceSettings.get"
+      - "compute.instantSnapshots.*"
+      - "compute.licenseCodes.*"
+      - "compute.licenses.*"
+      - "compute.projects.get"
+      - "compute.regionOperations.get"
+      - "compute.regionOperations.list"
+      - "compute.regions.*"
+      - "compute.resourcePolicies.*"
+      - "compute.snapshots.*"
+      - "compute.zoneOperations.get"
+      - "compute.zoneOperations.list"
+      - "compute.zones.*"
+      - "resourcemanager.projects.get"
+      - "resourcemanager.projects.list"
+      - "serviceusage.quotas.get"
+      - "serviceusage.services.get"
+      - "serviceusage.services.list"
+      - "iam.serviceAccounts.actAs"
+      - "iam.serviceAccounts.get"
+      - "iam.serviceAccounts.list"
+      - "resourcemanager.projects.get"
+      - "resourcemanager.projects.list"
     # If set to true, don't check whether the requested
     # roles have the necessary services enabled
     skipServiceCheck: true


### PR DESCRIPTION
Undo this revert: https://github.com/openshift/cluster-storage-operator/pull/426
Origin PR: https://github.com/openshift/cluster-storage-operator/pull/410

Note: After further clarification I've removed the usage of roles altogether in this PR, the permissions are equivalent to origin PR. 