### PR TITLE
CCO-251: replace instanceAdmin role with specific compute permissions

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -17,12 +17,14 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
+    # Required driver permissions: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/1a1f846c41c963e17b4757ce3beb0bf1e817d473/docs/kubernetes/user-guides/driver-install.md?plain=1#L17-L21
     predefinedRoles:
-      # FIXME: find a replacement for instanceAdmin, since the CSI driver
-      # only needs "compute.instances.[get|attachDisk|DetachDisk]"
-      - roles/compute.instanceAdmin
-      - roles/compute.storageAdmin
-      - roles/iam.serviceAccountUser
+      - "roles/compute.storageAdmin"
+      - "roles/iam.serviceAccountUser"
+    permissions:
+      - "compute.instances.get"
+      - "compute.instances.attachDisk"
+      - "compute.instances.detachDisk"
     # If set to true, don't check whether the requested
     # roles have the necessary services enabled
     skipServiceCheck: true


### PR DESCRIPTION
Undo this revert without any changes: https://github.com/openshift/cluster-storage-operator/pull/426
Origin PR: https://github.com/openshift/cluster-storage-operator/pull/410

This replaces https://github.com/openshift/cluster-storage-operator/pull/427, without having fine-grained permissions.