### PR TITLE
OCPBUGS-22422: Fix PodStartupStorageOperationsFailing alert

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -29,11 +29,19 @@ spec:
     - name: storage-operations.rules
       rules:
       - alert: PodStartupStorageOperationsFailing
-        # There was at least one failing operation in past 5 minutes *and* there was no successful one.
+        # There was at least one failing operation in past 5 minutes *and* there was no successful operation.
+        # To decide if there was no successful operation:
+        # - either `increase(status = "success")` must be zero, if the metric has data.
+        # - *or* if the metric has no data (= no operation for this volume plugin has even succeeded on this node),
+        #   `or increase(state != "success") * 0` will report zero successes. We know a failure metric exists,
+        #   so multiply it by zero to fill the gaps with zeroes.
         # Focus on attach and mount operations - they have the same diagnostic steps and are the most common.
         expr: |
           increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) > 0
-          and ignoring(status) increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m]) == 0
+            and ignoring(status) (sum without(status)
+              (increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m]))
+                or increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) * 0
+              ) == 0
         for: 5m
         labels:
           severity: info


### PR DESCRIPTION
The alert fired only when there was a successful operation on a node. If a CSI driver / volume plugin always failed on a node, the alert was silent, because `increase(storage_operation_duration_seconds_count{status = "success")[5m])` has no data.

Trying to fix it with more elaborate promql. When `increase(...{status = "success"}` has no data, supplement its value by `increase(...{status != "success"}) * 0`. We know that non-successful metric exists, so multiply it by zero to get a metric of successes with zero values.

Then use `sum without(status)` and `ignoring(status)` to merge the metrics by all other labels than status.

cc @openshift/storage 