### PR TITLE
STOR-1714: Release leadership on SIGTERM

### DIFF
--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -195,7 +195,7 @@ func (ssr *StandaloneStarter) StartOperator(ctx context.Context) error {
 	csoclients.StartInformers(ssr.commonClients, ctx.Done())
 
 	ssr.startControllers(ctx)
-	return fmt.Errorf("stopped")
+	return nil
 }
 
 func (ssr *StandaloneStarter) populateConfigs(clients *csoclients.Clients) []csioperatorclient.CSIOperatorConfig {
@@ -295,7 +295,7 @@ func (hsr *HyperShiftStarter) StartOperator(ctx context.Context) error {
 	csoclients.StartMgmtInformers(hsr.mgmtClient, ctx.Done())
 
 	hsr.startControllers(ctx)
-	return fmt.Errorf("stopped")
+	return nil
 }
 
 func (hsr *HyperShiftStarter) populateConfigs(clients *csoclients.Clients) []csioperatorclient.CSIOperatorConfig {


### PR DESCRIPTION
When RunOperator() returns no error, library-go waits for leader election goroutine to release the leadership before exiting.

An error returned from RunOperator() takes a shortcut and leads to much faster exit(1), not giving the election goroutine time to release its lease. A subsequent operator pod needs to wait for the old lease to expire, which slows down cluster upgrade and any development / debugging that needs the operator restarted.

cc @openshift/storage