### PR TITLE
STOR-1289: Move vSphere prometheus rules to CSO

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -7,6 +7,23 @@ metadata:
     role: alert-rules
 spec:
   groups:
+    # Rules to remove unnecessary labels before sending metrics through telemetry.
+    - name: vsphere-problem-detector-telemetry.rules
+      rules:
+      - expr: sum by(version)(vsphere_vcenter_info)
+        record: cluster:vsphere_vcenter_info:sum
+      - expr: sum by(version)(vsphere_esxi_version_total)
+        record: cluster:vsphere_esxi_version_total:sum
+      - expr: sum by(hw_version)(vsphere_node_hw_version_total)
+        record: cluster:vsphere_node_hw_version_total:sum
+      - expr: max by(source)(vsphere_topology_tags)
+        record: cluster:vsphere_topology_tags:max
+      - expr: max by(scope)(vsphere_infrastructure_failure_domains)
+        record: cluster:vsphere_infrastructure_failure_domains:max
+      - expr: max by(status)(vsphere_csi_migration{status=~"|LegacyDeprecatedInTreeDriver|CSIWithMigrationDriver"})
+        record: cluster:vsphere_csi_migration:max
+
+    # Alerting rules
     - name: vsphere-problem-detector.rules
       rules:
       - alert: VSphereOpenshiftNodeHealthFail

--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -20,8 +20,6 @@ spec:
         record: cluster:vsphere_topology_tags:max
       - expr: max by(scope)(vsphere_infrastructure_failure_domains)
         record: cluster:vsphere_infrastructure_failure_domains:max
-      - expr: max by(status)(vsphere_csi_migration{status=~"|LegacyDeprecatedInTreeDriver|CSIWithMigrationDriver"})
-        record: cluster:vsphere_csi_migration:max
 
     # Alerting rules
     - name: vsphere-problem-detector.rules


### PR DESCRIPTION
Move rules that are used to sanitize OCP metric for telemetry from cluster-monitoring-operator here. These rules are used only for storage metrics and should live with storage code.

cluster-monitoring-operator PR that removes the rules from their code: https://github.com/openshift/cluster-monitoring-operator/pull/2235