### PR TITLE
OCPBUGS-27159: Allow vSphere CSI driver to be disabled

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
@@ -41,6 +41,6 @@ func GetVMwareVSphereCSIOperatorConfig() CSIOperatorConfig {
 		CRAsset:             "csidriveroperators/vsphere/09_cr.yaml",
 		DeploymentAsset:     "csidriveroperators/vsphere/08_deployment.yaml",
 		ImageReplacer:       strings.NewReplacer(pairs...),
-		AllowDisabled:       false,
+		AllowDisabled:       true,
 	}
 }


### PR DESCRIPTION
vmware-vsphere-csi-driver-operator disables the driver when it cannot talk to vCenter, e.g. when it does not have valid credentials. This enables processing of condition `xxxDisabled: true` introduced in https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/218.

@openshift/storage 