### PR TITLE
STOR-1611: remove ibm-vpc-node-label-updater

### DIFF
--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -39,8 +39,6 @@ spec:
           value: ${LIVENESS_PROBE_IMAGE}
         - name: KUBE_RBAC_PROXY_IMAGE
           value: ${KUBE_RBAC_PROXY_IMAGE}
-        - name: NODE_LABEL_IMAGE
-          value: ${NODE_LABEL_IMAGE}
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -94,8 +94,6 @@ spec:
           value: quay.io/openshift/origin-ibm-vpc-block-csi-driver-operator:latest
         - name: IBM_VPC_BLOCK_DRIVER_IMAGE
           value: quay.io/openshift/origin-ibm-vpc-block-csi-driver:latest
-        - name: IBM_VPC_NODE_LABEL_UPDATER_IMAGE
-          value: quay.io/openshift/origin-ibm-vpc-node-label-updater:latest
         - name: POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE
           value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
         - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -97,8 +97,6 @@ spec:
           value: quay.io/openshift/origin-ibm-vpc-block-csi-driver-operator:latest
         - name: IBM_VPC_BLOCK_DRIVER_IMAGE
           value: quay.io/openshift/origin-ibm-vpc-block-csi-driver:latest
-        - name: IBM_VPC_NODE_LABEL_UPDATER_IMAGE
-          value: quay.io/openshift/origin-ibm-vpc-node-label-updater:latest
         - name: POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE
           value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
         - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -128,8 +128,6 @@ spec:
             value: quay.io/openshift/origin-ibm-vpc-block-csi-driver-operator:latest
           - name: IBM_VPC_BLOCK_DRIVER_IMAGE
             value: quay.io/openshift/origin-ibm-vpc-block-csi-driver:latest
-          - name: IBM_VPC_NODE_LABEL_UPDATER_IMAGE
-            value: quay.io/openshift/origin-ibm-vpc-node-label-updater:latest
           - name: POWERVS_BLOCK_CSI_DRIVER_OPERATOR_IMAGE
             value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
           - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -134,10 +134,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ibm-vpc-block-csi-driver:latest
-  - name: ibm-vpc-node-label-updater
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-ibm-vpc-node-label-updater:latest
   - name: powervs-block-csi-driver-operator
     from:
       kind: DockerImage

--- a/pkg/operator/csidriveroperator/csioperatorclient/ibm-vpc-block.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/ibm-vpc-block.go
@@ -1,9 +1,10 @@
 package csioperatorclient
 
 import (
-	"k8s.io/klog/v2"
 	"os"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -12,7 +13,6 @@ const (
 	IBMVPCBlockCSIDriverName          = "vpc.block.csi.ibm.io"
 	envIBMVPCBlockDriverOperatorImage = "IBM_VPC_BLOCK_DRIVER_OPERATOR_IMAGE"
 	envIBMVPCBlockDriverImage         = "IBM_VPC_BLOCK_DRIVER_IMAGE"
-	envIBMVPCNodeLabelUpdaterImage    = "IBM_VPC_NODE_LABEL_UPDATER_IMAGE"
 )
 
 func isNotExternalTopologyMode(status *configv1.InfrastructureStatus, isInstalled bool) bool {
@@ -32,7 +32,6 @@ func GetIBMVPCBlockCSIOperatorConfig() CSIOperatorConfig {
 	pairs := []string{
 		"${OPERATOR_IMAGE}", os.Getenv(envIBMVPCBlockDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envIBMVPCBlockDriverImage),
-		"${NODE_LABEL_IMAGE}", os.Getenv(envIBMVPCNodeLabelUpdaterImage),
 	}
 
 	return CSIOperatorConfig{

--- a/profile-patches/hypershift/10_deployment.yaml-patch
+++ b/profile-patches/hypershift/10_deployment.yaml-patch
@@ -32,22 +32,22 @@
     - name: guest-kubeconfig
       mountPath: /etc/guest-kubeconfig
 - op: add
-  path: /spec/template/spec/containers/0/env/37
+  path: /spec/template/spec/containers/0/env/36
   value:
     name: HYPERSHIFT_IMAGE
     value: quay.io/openshift/origin-control-plane:latest
 - op: add
-  path: /spec/template/spec/containers/0/env/38
+  path: /spec/template/spec/containers/0/env/37
   value:
     name: AWS_EBS_DRIVER_CONTROL_PLANE_IMAGE
     value: quay.io/openshift/origin-aws-ebs-csi-driver:latest
 - op: add
-  path: /spec/template/spec/containers/0/env/39
+  path: /spec/template/spec/containers/0/env/38
   value:
     name: AZURE_DISK_DRIVER_CONTROL_PLANE_IMAGE
     value: quay.io/openshift/origin-azure-disk-csi-driver-operator:latest
 - op: add
-  path: /spec/template/spec/containers/0/env/40
+  path: /spec/template/spec/containers/0/env/39
   value:
     name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
     value: quay.io/openshift/origin-csi-livenessprobe:latest


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1611
Since https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/89 merged, ibm-vpc-node-label-updater is no longer used or deployed. We can remove it from CSO and eventually from the payload.
/cc @openshift/storage
