### PR TITLE
OCPBUGS-28765: Remove master node selector from azure-csi-driver-operator deployment

### DIFF
--- a/assets/csidriveroperators/azure-disk/base/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/base/08_deployment.yaml
@@ -56,8 +56,6 @@ spec:
             cpu: 10m
       priorityClassName: system-cluster-critical
       serviceAccountName: azure-disk-csi-driver-operator
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -88,8 +88,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       priorityClassName: hypershift-control-plane
       serviceAccountName: azure-disk-csi-driver-operator
       tolerations:


### PR DESCRIPTION
The standalone patch already adds the master selector to the deployment. It should not be in the base yaml.