### PR TITLE
OCPBUGS-28748: log default storage class names when collector is triggered

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -53,12 +53,14 @@ func countStorageClasses(clients *csoclients.Clients) {
 				klog.Fatalf("Failed to get existing storage classes: %s", err)
 			}
 			defaultSCCount := 0
+			var defaultSCNames []string
 			for _, sc := range existingSCs {
 				if sc.Annotations[defaultScAnnotationKey] == "true" {
 					defaultSCCount++
+					defaultSCNames = append(defaultSCNames, sc.Name)
 				}
 			}
-			klog.V(4).Infof("Current default StorageClass count %v", defaultSCCount)
+			klog.V(4).Infof("Current default StorageClass count: %v (%v)", defaultSCCount, defaultSCNames)
 			return float64(defaultSCCount)
 		},
 	))


### PR DESCRIPTION
It is more helpful to show which storage classes were detected as default. There's an alert when more than one default is present and this message might help debug such cases in the future.

Message example:
```
I0221 16:55:09.385977   65866 starter.go:63] Current default StorageClass count: 2 ([thin-csi thin-csi2])
```
