### PR TITLE
WIP: Remove iam.serviceAccountUser role from GCP credentials

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -20,7 +20,6 @@ spec:
     # Required driver permissions: https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/1a1f846c41c963e17b4757ce3beb0bf1e817d473/docs/kubernetes/user-guides/driver-install.md?plain=1#L17-L21
     predefinedRoles:
       - "roles/compute.storageAdmin"
-      - "roles/iam.serviceAccountUser"
     permissions:
       - "compute.instances.get"
       - "compute.instances.attachDisk"


### PR DESCRIPTION
Checking if this role is required at all.