### PR TITLE
MON-2065: manifests: add k8s storage rules

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -68,3 +68,103 @@ spec:
       # Pod with set SELinux context successfuly uses a volume (i.e. "mount -o context" would work).
       - expr: sum by(volume_plugin) (volume_manager_selinux_volumes_admitted_total{volume_plugin !~".*-e2e-.*"})
         record: cluster:volume_manager_selinux_volumes_admitted_total
+    - name: kubernetes-storage
+    # These alerts originate from https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/de834e9a291b49396125768f041e2078763f48b5/alerts/storage_alerts.libsonnet
+      rules:
+      - alert: KubePersistentVolumeFillingUp
+        annotations:
+          description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is only {{ $value | humanizePercentage }} free.
+          runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
+          summary: PersistentVolume is filling up.
+        # Fire alert if only 3% capacity is left but only of used_bytes > 0
+        # (block storage will report 0), if its not read_only or if the alert
+        # is not explicitly disabled
+        expr: |
+          (
+            kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_capacity_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+          ) < 0.03
+          and
+          kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+        for: 1m
+        labels:
+          severity: critical
+      - alert: KubePersistentVolumeFillingUp
+        annotations:
+          description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.
+          runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeFillingUp.md
+          summary: PersistentVolume is filling up.
+        expr: |
+          (
+            kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_capacity_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+          ) < 0.15
+          and
+          kubelet_volume_stats_used_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+          and
+          predict_linear(kubelet_volume_stats_available_bytes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: KubePersistentVolumeInodesFillingUp
+        annotations:
+          description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} only has {{ $value | humanizePercentage }} free inodes.
+          runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
+          summary: PersistentVolumeInodes are filling up.
+        # See comment for KubePersistentVolumeFillingUp
+        expr: |
+          (
+            kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_inodes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+          ) < 0.03
+          and
+          kubelet_volume_stats_inodes_used{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+        for: 1m
+        labels:
+          severity: critical
+      - alert: KubePersistentVolumeInodesFillingUp
+        annotations:
+          description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} is expected to run out of inodes within four days. Currently {{ $value | humanizePercentage }} of its inodes are free.
+          runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/KubePersistentVolumeInodesFillingUp.md
+          summary: PersistentVolumeInodes are filling up.
+        expr: |
+          (
+            kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_inodes{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}
+          ) < 0.15
+          and
+          kubelet_volume_stats_inodes_used{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"} > 0
+          and
+          predict_linear(kubelet_volume_stats_inodes_free{namespace=~"(openshift-.*|kube-.*|default)",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_access_mode{namespace=~"(openshift-.*|kube-.*|default)", access_mode="ReadOnlyMany"} == 1
+          unless on(cluster, namespace, persistentvolumeclaim)
+          kube_persistentvolumeclaim_labels{namespace=~"(openshift-.*|kube-.*|default)",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+        for: 1h
+        labels:
+          severity: warning
+      - alert: KubePersistentVolumeErrors
+        annotations:
+          description: The persistent volume {{ $labels.persistentvolume }} {{ with $labels.cluster -}} on Cluster {{ . }} {{- end }} has status {{ $labels.phase }}.
+          summary: PersistentVolume is having issues with provisioning.
+        expr: |
+          kube_persistentvolume_status_phase{phase=~"Failed|Pending",namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0
+        for: 5m
+        labels:
+          severity: warning


### PR DESCRIPTION
These rules have until now lived in
https://github.com/openshift/cluster-monitoring-operator, where they where generated from
https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/de834e9a291b49396125768f041e2078763f48b5/alerts/storage_alerts.libsonnet. This however rarely changes so I'm committing the manifest here along with some comments.