### PR TITLE
OCPBUGS-34590: revert vsphere problem detector controller name change

### DIFF
--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
@@ -123,7 +123,7 @@ func (c *VSphereProblemDetectorStarter) createVSphereProblemDetectorManager(
 		"vsphere_problem_detector/10_service.yaml",
 	}
 
-	vSphereProblemDetectorName := "VSphereProblemDetectorDeploymentController"
+	vSphereProblemDetectorName := "VSphereProblemDetectorStarterStaticController"
 	mgr = mgr.WithController(staticresourcecontroller.NewStaticResourceController(
 		vSphereProblemDetectorName,
 		assets.ReadFile,


### PR DESCRIPTION
This is a partial revert of https://github.com/openshift/cluster-storage-operator/pull/456

Unless we have to change the name of the controller for some reason we could revert it back instead of cleaning it up.