### PR TITLE
STOR-1593: add patch role to PVs for provisioner

### DIFF
--- a/manifests/09_sidecar-main_provisioner_role.yaml
+++ b/manifests/09_sidecar-main_provisioner_role.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
It is required to update provisioner permissions (add patch permission) because of https://github.com/kubernetes-csi/external-provisioner/pull/1155, which we are Rebasing in https://github.com/openshift/csi-external-provisioner/pull/98. This PR needs to be merged before the rebase one.

/cc @openshift/storage 