### PR TITLE
OCPBUGS-36169: deactivate MultipleDefaultStorageClasses alert immediately after being fixed

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -16,7 +16,7 @@ spec:
     - name: default-storage-classes.rules
       rules:
       - alert: MultipleDefaultStorageClasses
-        expr:  max_over_time(default_storage_class_count[5m]) > 1
+        expr:  min_over_time(default_storage_class_count[5m]) > 1
         for: 10m
         labels:
           severity: warning


### PR DESCRIPTION
The MultipleDefaultStorageClasses alert was present 5 minutes after this problem was fixed and there was only 1 default storage class. This PR fixes this issue. 