### PR TITLE
STOR-1767: add env var OPERATOR_NAME to vsphere csi operator deployment

### DIFF
--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -44,6 +44,8 @@ spec:
           value: ${VMWARE_VSPHERE_SYNCER_IMAGE}
         - name: KUBE_RBAC_PROXY_IMAGE
           value: ${KUBE_RBAC_PROXY_IMAGE}
+        - name: OPERATOR_NAME
+          value: vmware-vsphere-csi-driver-operator
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/233 will do `allowOperatorRemovedState=True` for vsphere csi operator. This will trigger finalazer check in library-go:

```
	if management.IsOperatorRemovable() {
		if err := v1helpers.EnsureFinalizer(ctx, c.operatorClient, c.name); err != nil {
```

`EnsureFinalizer()`, in turn, calculates finalizer name either as `os.Getenv("OPERATOR_NAME")` or `os.Args[0]`. The latter doesn't work for vsphere because leading slash in `/usr/bin/vmware-vsphere-csi-driver-operator` is not allowed:

```
E0701 19:43:32.342151       1 base_controller.go:268] VMwareVSphereDriverControllerServiceController reconciliation failed: ClusterCSIDriver.operator.openshift.io "csi.vsphere.vmware.com" is invalid: metadata.finalizers: Invalid value: "/usr/bin/vmware-vsphere-csi-driver-operator.operator.openshift.io/VMwareVSphereDriverControllerServiceController": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```