### PR TITLE
CFE-879: Add TagUser role to creadentials request of GCP PD operator

### DIFF
--- a/manifests/03_credentials_request_gcp.yaml
+++ b/manifests/03_credentials_request_gcp.yaml
@@ -21,6 +21,7 @@ spec:
     predefinedRoles:
       - "roles/compute.storageAdmin"
       - "roles/iam.serviceAccountUser"
+      - "roles/resourcemanager.tagUser"
     permissions:
       - "compute.instances.get"
       - "compute.instances.attachDisk"


### PR DESCRIPTION
Add `TagUser` role to the credentials request created for the GCP PD storage operator, required adding tags to the GCP resources created by the driver.