### PR TITLE
OCPBUGS-37663: include azure perms for route table

### DIFF
--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -17,6 +17,7 @@ spec:
     kind: AzureProviderSpec
     permissions:
       - 'Microsoft.Network/networkSecurityGroups/join/action'
+      - 'Microsoft.Network/routeTables/join/action'
       - 'Microsoft.Network/virtualNetworks/subnets/read'
       - 'Microsoft.Network/virtualNetworks/subnets/write'
       - 'Microsoft.Storage/storageAccounts/delete'


### PR DESCRIPTION
Now that the installer has switched from Terraform to using cluster api to provision Azure clusters, the node subnet is created with an (empty) route table attached. In order to provision a volume on the subnet, permissions to join the route table are required.