### PR TITLE
NO-JIRA: create CRDs from openshift/api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ RUN make
 FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-storage-operator/cluster-storage-operator /usr/bin/
 COPY manifests /manifests
-COPY vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml manifests/05_crd_operator.yaml
-COPY vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml manifests/04_cluster_csi_driver_crd.yaml
 ENTRYPOINT ["/usr/bin/cluster-storage-operator"]
 LABEL io.openshift.release.operator true
 LABEL io.k8s.display-name="OpenShift Cluster Storage Operator" \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -6,8 +6,6 @@ RUN make
 FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/openshift/cluster-storage-operator/cluster-storage-operator /usr/bin/
 COPY manifests /manifests
-COPY vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml manifests/05_crd_operator.yaml
-COPY vendor/github.com/openshift/api/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml manifests/04_cluster_csi_driver_crd.yaml
 ENTRYPOINT ["/usr/bin/cluster-storage-operator"]
 LABEL io.openshift.release.operator true
 LABEL io.k8s.display-name="OpenShift Cluster Storage Operator" \


### PR DESCRIPTION
CRD schemas are now created here: https://github.com/openshift/api/pull/2032.

This allso prevents changes like [this](https://github.com/openshift/cluster-storage-operator/commit/076e178df7aa8bd9753a2b5de9aa14542412a757) when adding new TechPreview fields to ClusterCSIDriver CRDs.

CC @openshift/storage 