### PR TITLE
WIP: STOR-1140: Use kubeconfig specific for AWS-EBS CSI operator

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -63,4 +63,4 @@ spec:
       volumes:
         - name: guest-kubeconfig
           secret:
-            secretName: service-network-admin-kubeconfig
+            secretName: aws-ebs-csi-driver-operator-kubeconfig

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -104,4 +104,4 @@ spec:
       volumes:
       - name: guest-kubeconfig
         secret:
-          secretName: service-network-admin-kubeconfig
+          secretName: aws-ebs-csi-driver-operator-kubeconfig


### PR DESCRIPTION
Let's use fine-grained kubeconfig `aws-ebs-csi-driver-operator-kubeconfig` instead of omnipotent `service-network-admin-kubeconfig`.

This PR depends on: https://github.com/openshift/hypershift/pull/4790