### PR TITLE
NO-JIRA: assets: shared-resource: hypershift: add pull-secret to operator SA

### DIFF
--- a/assets/csidriveroperators/shared-resource/hypershift/mgmt/02_sa.yaml
+++ b/assets/csidriveroperators/shared-resource/hypershift/mgmt/02_sa.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: shared-resource-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
+imagePullSecrets:
+  - name: pull-secret


### PR DESCRIPTION
The ServiceAccount for the shared-resource-csi-driver-operator that runs on the mgmt cluster does not have the HCP pull secret configured
```
$ oc get sa shared-resource-csi-driver-operator -oyaml
apiVersion: v1
imagePullSecrets:
- name: shared-resource-csi-driver-operator-dockercfg-qwzsg
kind: ServiceAccount
...
```

This causes image pull failure
```
16m         Warning   Failed                        pod/shared-resource-csi-driver-operator-7d9798f764-ft9jg    Failed to pull image "registry.ci.openshift.org/ocp/4.18-2024-10-10-065553@sha256:1be01d122d1e9375f318548763608b461d62c72b78457962ed14f5b60526738d": unable to retrieve auth token: invalid username/password: authentication required
```

cc @jsafrane @gnufied 