### PR TITLE
OCPBUGS-43794: add ability to control kube rbac proxy container image on controlplane

### DIFF
--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
@@ -51,6 +51,8 @@ spec:
             value: ${DRIVER_CONTROL_PLANE_IMAGE}
           - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
             value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
+          - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+            value: ${KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE}
         volumeMounts:
           - mountPath: /etc/guest-kubeconfig
             name: guest-kubeconfig

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -54,6 +54,8 @@ spec:
           value: ${DRIVER_CONTROL_PLANE_IMAGE}
         - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
           value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
+        - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+          value: ${KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE}
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
         - name: PROVISIONER_IMAGE

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
@@ -51,6 +51,8 @@ spec:
             value: ${DRIVER_CONTROL_PLANE_IMAGE}
           - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
             value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
+          - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+            value: ${KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE}
         volumeMounts:
           - mountPath: /etc/guest-kubeconfig
             name: guest-kubeconfig

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -54,6 +54,8 @@ spec:
           value: ${DRIVER_CONTROL_PLANE_IMAGE}
         - name: LIVENESS_PROBE_CONTROL_PLANE_IMAGE
           value: ${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}
+        - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+          value: ${KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE}
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
         - name: PROVISIONER_IMAGE

--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -109,6 +109,8 @@ spec:
           value: quay.io/openshift/origin-csi-livenessprobe:latest
         - name: AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-azure-file-csi-driver-operator:latest
+        - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+          value: quay.io/openshift/origin-kube-rbac-proxy:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest

--- a/pkg/operator/csidriveroperator/util.go
+++ b/pkg/operator/csidriveroperator/util.go
@@ -28,6 +28,7 @@ const (
 	envToolsImage               = "TOOLS_IMAGE"
 
 	envLivenessProbeControlPlaneImage = "LIVENESS_PROBE_CONTROL_PLANE_IMAGE"
+	envKubeRBACProxyControlPlaneImage = "KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE"
 )
 
 var (
@@ -40,6 +41,7 @@ var (
 		"${LIVENESS_PROBE_IMAGE}", os.Getenv(envLivenessProbeImage),
 		"${LIVENESS_PROBE_CONTROL_PLANE_IMAGE}", os.Getenv(envLivenessProbeControlPlaneImage),
 		"${KUBE_RBAC_PROXY_IMAGE}", os.Getenv(envKubeRBACProxyImage),
+		"${KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE}", os.Getenv(envKubeRBACProxyControlPlaneImage),
 		"${TOOLS_IMAGE}", os.Getenv(envToolsImage),
 	)
 )

--- a/profile-patches/hypershift/10_deployment.yaml-patch
+++ b/profile-patches/hypershift/10_deployment.yaml-patch
@@ -56,6 +56,11 @@
   value:
     name: AZURE_FILE_DRIVER_CONTROL_PLANE_IMAGE
     value: quay.io/openshift/origin-azure-file-csi-driver-operator:latest
+- op: add
+  path: /spec/template/spec/containers/0/env/41
+  value:
+    name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
+    value: quay.io/openshift/origin-kube-rbac-proxy:latest
 # Add cmdline args
 - op: add
   path: /spec/template/spec/containers/0/args/-


### PR DESCRIPTION
This is a manual cherry-pick of:

- https://github.com/openshift/cluster-storage-operator/pull/515
- https://github.com/openshift/cluster-storage-operator/pull/518
- https://github.com/openshift/cluster-storage-operator/pull/522