### PR TITLE
HOSTEDCP-2033: Correct ARO HCP environment vars for CSI driver operator deployment

### DIFF
--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -137,13 +137,13 @@ func (c *HyperShiftDeploymentController) Sync(ctx context.Context, syncCtx facto
 	// certificates, related to the client IDs, in a volume on the azure-disk-csi-controller and
 	// azure-file-csi-controller deployments.
 	var envVars []corev1.EnvVar
-	if os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK") != "" && requiredCopy.ObjectMeta.Name == "azure-disk-csi-driver-operator" {
+	if os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK") != "" && requiredCopy.Name == "azure-disk-csi-driver-operator" {
 		envVars = []corev1.EnvVar{
 			{Name: "ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK", Value: os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK")},
 		}
 	}
 
-	if os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE") != "" && requiredCopy.ObjectMeta.Name == "azure-file-csi-driver-operator" {
+	if os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE") != "" && requiredCopy.Name == "azure-file-csi-driver-operator" {
 		envVars = []corev1.EnvVar{
 			{Name: "ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE", Value: os.Getenv("ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE")},
 		}


### PR DESCRIPTION
- Correct ARO HCP environment vars for CSI driver operator deployment(We deepCopy the driver operator deploy in proxy hook https://github.com/openshift/cluster-storage-operator/compare/master...Phaow:hotfix?expand=1#diff-40fd8e85c74d747fd9f412fcf74ff56c582d612aaf2775c422d6f97729f3a173R129-R130 and finally apply the deepCopy object, so we needs use the deepCopy object to inject the new env vars for dirver operatos otherwise the new env vars won't be added).
- Only inject the used env var for different dirver operators. (Previous codes will inject both `ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK` and `ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE` env vars for both disk and file dirver operators while each operator only needs its own one)

**Local test record on azure aks hcp**

```console
$ oc get deploy azure-disk-csi-driver-operator -oyaml|grep -i 'ARO_HCP_SECRET_PROVIDER_CLASS_FOR'
        - name: ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK
$ oc get deploy azure-file-csi-driver-operator -oyaml|grep -i 'ARO_HCP_SECRET_PROVIDER_CLASS_FOR'
        - name: ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE

```

