### PR TITLE
NO-JIRA: Remove kustomize-related annotations from generated assets

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_ebs.csi.aws.com.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_ebs.csi.aws.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: ebs.csi.aws.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: aws-ebs-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_aws-ebs-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_aws-ebs-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: aws-ebs-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/kustomization.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/kustomization.yaml
@@ -17,3 +17,11 @@ patches:
         name: PLACEHOLDER
     target:
       annotationSelector: "storage.openshift.io/remove-from=guest"
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: guest
   name: aws-ebs-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
 spec:

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/kustomization.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/kustomization.yaml
@@ -27,3 +27,11 @@ patches:
       kind: Kustomization
       metadata:
         name: PLACEHOLDER
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=guest"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/operator.openshift.io_v1_clustercsidriver_ebs.csi.aws.com.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/operator.openshift.io_v1_clustercsidriver_ebs.csi.aws.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: ebs.csi.aws.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: aws-ebs-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_aws-ebs-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_aws-ebs-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: aws-ebs-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/aws-ebs/standalone/kustomization.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/kustomization.yaml
@@ -5,8 +5,16 @@ patches:
   - path: monitoring_role.patch.yaml
     target:
       kind: Role
-      version: v1    
+      version: v1
   - path: deployment.patch.yaml
     target:
       kind: Deployment
       version: v1
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_disk.csi.azure.com.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_disk.csi.azure.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: disk.csi.azure.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-disk-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-disk-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-disk-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-disk-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/kustomization.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/kustomization.yaml
@@ -17,3 +17,11 @@ patches:
         name: PLACEHOLDER
     target:
       annotationSelector: "storage.openshift.io/remove-from=guest"
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   annotations:
     config.openshift.io/inject-proxy: azure-disk-csi-driver-operator
-    storage.openshift.io/remove-from: guest
   name: azure-disk-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
 spec:

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/kustomization.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/kustomization.yaml
@@ -27,3 +27,11 @@ patches:
       kind: Kustomization
       metadata:
         name: PLACEHOLDER
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=guest"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-disk/standalone/generated/operator.openshift.io_v1_clustercsidriver_disk.csi.azure.com.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/operator.openshift.io_v1_clustercsidriver_disk.csi.azure.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: disk.csi.azure.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-disk-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-disk-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-disk-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-disk-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/azure-disk/standalone/kustomization.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/kustomization.yaml
@@ -10,3 +10,11 @@ patches:
     target:
       kind: Deployment
       version: v1
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-file/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_file.csi.azure.com.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/guest/generated/operator.openshift.io_v1_clustercsidriver_file.csi.azure.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: file.csi.azure.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-file-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-file-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-file-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-file-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/azure-file/hypershift/guest/kustomization.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/guest/kustomization.yaml
@@ -17,3 +17,11 @@ patches:
         name: PLACEHOLDER
     target:
       annotationSelector: "storage.openshift.io/remove-from=guest"
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -3,7 +3,6 @@ kind: Deployment
 metadata:
   annotations:
     config.openshift.io/inject-proxy: azure-file-csi-driver-operator
-    storage.openshift.io/remove-from: guest
   name: azure-file-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}
 spec:

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/kustomization.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/kustomization.yaml
@@ -27,3 +27,11 @@ patches:
       kind: Kustomization
       metadata:
         name: PLACEHOLDER
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=guest"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/azure-file/standalone/generated/operator.openshift.io_v1_clustercsidriver_file.csi.azure.com.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/operator.openshift.io_v1_clustercsidriver_file.csi.azure.com.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.openshift.io/v1
 kind: ClusterCSIDriver
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: file.csi.azure.com
   namespace: openshift-cluster-csi-drivers
 spec:

--- a/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-file-csi-driver-operator-clusterrole
 rules:
 - apiGroups:

--- a/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-file-csi-driver-operator-clusterrolebinding.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_azure-file-csi-driver-operator-clusterrolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: mgmt
   name: azure-file-csi-driver-operator-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/assets/csidriveroperators/azure-file/standalone/kustomization.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/kustomization.yaml
@@ -10,3 +10,11 @@ patches:
     target:
       kind: Deployment
       version: v1
+  # remove these annotations as they're just noise post-kustomization
+  # note that '~1' is the escaped form of '/'
+  # https://datatracker.ietf.org/doc/html/rfc6901
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=mgmt"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"


### PR DESCRIPTION
These provide no value once we have run kustomize and could be confusing. Remove them.

Yes, this is a nit but I think it's helpful.
