### PR TITLE
NO-JIRA: Remove redundant clusterrole rules

### DIFF
--- a/assets/csidriveroperators/aws-ebs/base/05_clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/base/05_clusterrole.yaml
@@ -280,21 +280,8 @@ rules:
   - watch
 # Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
 - apiGroups:
-  - "authentication.k8s.io"
+  - authentication.k8s.io
   resources:
-  - "tokenreviews"
+  - tokenreviews
   verbs:
-  - "create"
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
-  - delete
-  

--- a/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -283,15 +283,3 @@ rules:
   - tokenreviews
   verbs:
   - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml
@@ -283,15 +283,3 @@ rules:
   - tokenreviews
   verbs:
   - create
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete

--- a/assets/csidriveroperators/azure-disk/base/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/base/06_clusterrole.yaml
@@ -95,18 +95,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ''
   resources:
   - nodes
@@ -302,8 +290,8 @@ rules:
   - watch
 # Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
 - apiGroups:
-  - "authentication.k8s.io"
+  - authentication.k8s.io
   resources:
-  - "tokenreviews"
+  - tokenreviews
   verbs:
-  - "create"
+  - create

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -94,18 +94,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - nodes

--- a/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -94,18 +94,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - nodes

--- a/assets/csidriveroperators/azure-file/base/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/base/06_clusterrole.yaml
@@ -95,18 +95,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ''
   resources:
   - nodes
@@ -306,8 +294,8 @@ rules:
   - watch
 # Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
 - apiGroups:
-  - "authentication.k8s.io"
+  - authentication.k8s.io
   resources:
-  - "tokenreviews"
+  - tokenreviews
   verbs:
-  - "create"
+  - create

--- a/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
@@ -94,18 +94,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - nodes

--- a/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-file-csi-driver-operator-clusterrole.yaml
@@ -94,18 +94,6 @@ rules:
   - watch
   - delete
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION
These are already defined in the role and do not need to be duplicated in the cluster role.

As always, the real changes are in the 'base' directory and the changes in 'generated' are auto-generated by 'make update'.

While we're here, we also remove some unnecessary quotes for the source definition.
