### PR TITLE
OCPBUGS-43767: Fix PodStartupStorageOperationsFailing alert

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -40,8 +40,8 @@ spec:
         expr: |
           increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) > 0
             and ignoring(status) (sum without(status)
-              (increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m]))
-                or increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) * 0
+              (increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[5m])
+                or increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[5m]) * 0)
               ) == 0
         for: 5m
         labels:


### PR DESCRIPTION
The alert gives false-positives for the following scenario (100% repoducible): failure, success, ~2mins pause, failure, success, ~2mins pause, etc.

The essence of issue (false-positives) is a typo in promql query: the closing bracket for `sum without(status) (` came too early, before `or`. This is a problem because the `sum` operator is greedy, it is stronger then `or`. So it was applied to the first operand in brackets:
```
sum without(status) (increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[60m]))
```
The patch fixes issue by moving closing bracket farhter, beyond `or ...`:
```
sum without(status) (increase(storage_operation_duration_seconds_count{status = "success", operation_name =~"volume_attach|volume_mount"}[60m]) or increase(storage_operation_duration_seconds_count{status != "success", operation_name =~"volume_attach|volume_mount"}[60m]) * 0)
```