### PR TITLE
NO-JIRA: Add openstack-approvers to root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,4 @@
 approvers:
-  - jsafrane
-  - tsmetana
-  - gnufied
-  - bertinatto
-  - dobsonj
-  - RomanBednar
-  - mpatlasov
+- openshift-storage-maintainers
+- openstack-approvers
 component: "Storage / Operators"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,14 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  openstack-approvers:
+  - EmilienM
+  - mandre
+  openshift-storage-maintainers:
+  - jsafrane
+  - tsmetana
+  - gnufied
+  - bertinatto
+  - dobsonj
+  - RomanBednar
+  - mpatlasov


### PR DESCRIPTION
To allow us to review/approve OpenStack-related changes to `openshift/release`, since the `OWNERS` files there are auto-generated from this one.

https://github.com/openshift/csi-operator/pull/315 does this for `openshift/csi-operator`.
