### PR TITLE
OSASINFRA-3632: Rename expected config map for HCP management cluster

### DIFF
--- a/assets/csidriveroperators/openstack-cinder/base/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/base/07_deployment.yaml
@@ -62,12 +62,6 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: openstack-cinder-csi-driver-operator
       volumes:
-      - name: secret-cinderplugin
-        secret:
-          secretName: openstack-cloud-credentials
-          items:
-            - key: clouds.yaml
-              path: clouds.yaml
       - name: cacert
         # If present, extract ca-bundle.pem to
         # /etc/kubernetes/static-pod-resources/configmaps/cloud-config
@@ -80,3 +74,9 @@ spec:
           - key: ca-bundle.pem
             path: ca-bundle.pem
           optional: true
+      - name: secret-cinderplugin
+        secret:
+          secretName: openstack-cloud-credentials
+          items:
+            - key: clouds.yaml
+              path: clouds.yaml

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
@@ -57,6 +57,13 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-control-plane
       volumes:
+        - configMap:
+            items:
+            - key: ca-bundle.pem
+              path: ca-bundle.pem
+            name: openstack-cloud-config
+            optional: true
+          name: cacert
         - name: guest-kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -106,16 +106,16 @@ spec:
         operator: Equal
         value: ${CONTROLPLANE_NAMESPACE}
       volumes:
-      - name: guest-kubeconfig
-        secret:
-          secretName: service-network-admin-kubeconfig
       - configMap:
           items:
           - key: ca-bundle.pem
             path: ca-bundle.pem
-          name: cloud-provider-config
+          name: openstack-cloud-config
           optional: true
         name: cacert
+      - name: guest-kubeconfig
+        secret:
+          secretName: service-network-admin-kubeconfig
       - name: secret-cinderplugin
         secret:
           items:

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -109,12 +109,6 @@ spec:
       - name: guest-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig
-      - name: secret-cinderplugin
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
       - configMap:
           items:
           - key: ca-bundle.pem
@@ -122,3 +116,9 @@ spec:
           name: cloud-provider-config
           optional: true
         name: cacert
+      - name: secret-cinderplugin
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials

--- a/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -70,12 +70,6 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-      - name: secret-cinderplugin
-        secret:
-          items:
-          - key: clouds.yaml
-            path: clouds.yaml
-          secretName: openstack-cloud-credentials
       - configMap:
           items:
           - key: ca-bundle.pem
@@ -83,3 +77,9 @@ spec:
           name: cloud-provider-config
           optional: true
         name: cacert
+      - name: secret-cinderplugin
+        secret:
+          items:
+          - key: clouds.yaml
+            path: clouds.yaml
+          secretName: openstack-cloud-credentials


### PR DESCRIPTION
Hypershift stores the cloud configuration info in a different config map to Installer: `openstack-cloud-config` instead of `cloud-provider-config`. Update the manifests to reflect this.
