### PR TITLE
STOR-2078: Add OPERATOR_IMAGE_VERSION var to AWS-EBS operator

### DIFF
--- a/pkg/operator/csidriveroperator/csioperatorclient/aws.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/aws.go
@@ -20,6 +20,7 @@ func GetAWSEBSCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 		"${OPERATOR_IMAGE}", os.Getenv(envAWSEBSDriverOperatorImage),
 		"${DRIVER_IMAGE}", os.Getenv(envAWSEBSDriverImage),
 		"${DRIVER_CONTROL_PLANE_IMAGE}", os.Getenv(envAWSEBSDriverControlPlaneImage),
+		"${OPERATOR_IMAGE_VERSION}", os.Getenv(envOperatorImageVersion),
 	}
 
 	csiDriverConfig := CSIOperatorConfig{


### PR DESCRIPTION
Adding `OPERATOR_IMAGE_VERSION` variable to AWS EBS operator.