### PR TITLE
OCPBUGS-45073: Support HCP labels

### DIFF
--- a/pkg/operator/csidriveroperator/deploymentcontroller.go
+++ b/pkg/operator/csidriveroperator/deploymentcontroller.go
@@ -179,7 +179,7 @@ func (c *CSIDriverOperatorDeploymentController) Sync(ctx context.Context, syncCt
 		replacers = append(replacers, c.csiOperatorConfig.ImageReplacer)
 	}
 
-	required, err := csoutils.GetRequiredDeployment(c.csiOperatorConfig.DeploymentAsset, opSpec, nil, nil, replacers...)
+	required, err := csoutils.GetRequiredDeployment(c.csiOperatorConfig.DeploymentAsset, opSpec, nil, nil, nil, replacers...)
 	if err != nil {
 		return fmt.Errorf("failed to generate required Deployment: %s", err)
 	}


### PR DESCRIPTION
HCP is adding a new API field to allow users creating HCP clusters to set custom labels on all HCP pods https://github.com/openshift/hypershift/pull/5114. cluster-storage-operator needs to integrate this feature in the same way it integrated the NodeSelector feature for HCP.