### PR TITLE
OCPBUGS-50668: fix Vsphere cluster Storage operator in Unavailable state

### DIFF
--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/management"
 	"github.com/openshift/library-go/pkg/operator/managementstatecontroller"
+	"github.com/openshift/library-go/pkg/operator/staleconditions"
 	"github.com/openshift/library-go/pkg/operator/status"
 	rbacv1 "k8s.io/api/rbac/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -120,6 +121,15 @@ func (csr *commonStarter) CreateCommonControllers() error {
 	// This controller syncs the operator log level with the value set in the CR.Spec.OperatorLogLevel
 	logLevelController := loglevel.NewClusterOperatorLoggingController(csr.commonClients.OperatorClient, csr.eventRecorder)
 	csr.controllers = append(csr.controllers, logLevelController)
+
+	// This controller removes VSphereProblemDetectorDeploymentControllerAvailable condition in the storage status
+	staleConditionsController := staleconditions.NewRemoveStaleConditionsController(
+		"RemoveStaleConditionsController",
+		[]string{"VSphereProblemDetectorDeploymentControllerAvailable"},
+		csr.commonClients.OperatorClient,
+		csr.eventRecorder,
+	)
+	csr.controllers = append(csr.controllers, staleConditionsController)
 
 	// This controller observes a config (proxy for now) and writes it to CR.Spec.ObservedConfig for later use by the operator
 	configObserverController := configobservercontroller.NewConfigObserverController(csr.commonClients, csr.eventRecorder)

--- a/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/staleconditions/remove_stale_conditions.go
@@ -1,0 +1,71 @@
+package staleconditions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/library-go/pkg/apiserver/jsonpatch"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+type RemoveStaleConditionsController struct {
+	controllerInstanceName string
+	conditionTypesToRemove []string
+	operatorClient         v1helpers.OperatorClient
+}
+
+func NewRemoveStaleConditionsController(
+	instanceName string,
+	conditionTypes []string,
+	operatorClient v1helpers.OperatorClient,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &RemoveStaleConditionsController{
+		controllerInstanceName: factory.ControllerInstanceName(instanceName, "RemoveStaleConditions"),
+		conditionTypesToRemove: conditionTypes,
+		operatorClient:         operatorClient,
+	}
+	return factory.New().
+		ResyncEvery(time.Minute).
+		WithSync(c.sync).
+		WithInformers(operatorClient.Informer()).
+		ToController(
+			c.controllerInstanceName,
+			eventRecorder.WithComponentSuffix("remove-stale-conditions"),
+		)
+}
+
+func (c RemoveStaleConditionsController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	_, operatorStatus, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return err
+	}
+
+	var removedCount int
+	jsonPatch := jsonpatch.New()
+	for i, existingCondition := range operatorStatus.Conditions {
+		for _, conditionTypeToRemove := range c.conditionTypesToRemove {
+			if existingCondition.Type != conditionTypeToRemove {
+				continue
+			}
+			removeAtIndex := i
+			if !jsonPatch.IsEmpty() {
+				removeAtIndex = removeAtIndex - removedCount
+			}
+			jsonPatch.WithRemove(
+				fmt.Sprintf("/status/conditions/%d", removeAtIndex),
+				jsonpatch.NewTestCondition(fmt.Sprintf("/status/conditions/%d/type", removeAtIndex), conditionTypeToRemove),
+			)
+			removedCount++
+		}
+	}
+
+	if jsonPatch.IsEmpty() {
+		return nil
+	}
+
+	return c.operatorClient.PatchOperatorStatus(ctx, jsonPatch)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -336,6 +336,7 @@ github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 github.com/openshift/library-go/pkg/operator/resourcesynccontroller
+github.com/openshift/library-go/pkg/operator/staleconditions
 github.com/openshift/library-go/pkg/operator/staticresourcecontroller
 github.com/openshift/library-go/pkg/operator/status
 github.com/openshift/library-go/pkg/operator/v1helpers


### PR DESCRIPTION
During upgrade from 4.15 to 4.16 an error can happen when VSphereProblemDetectorDeploymentControllerAvailable condition is present from 4.15, but 4.16 and later versions don't use it anymore and users can get stuck during upgrade. This PR fixed the problem.

To test, add the condition using `oc edit --subresource=status --output-patch storage cluster`, after that CSO should remove it.

@openshift/storage 