### PR TITLE
OCPBUGS-55182: Add required Microsoft.Network/natGateways/join/action permission

### DIFF
--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -18,6 +18,7 @@ spec:
     permissions:
       - 'Microsoft.Network/networkSecurityGroups/join/action'
       - 'Microsoft.Network/routeTables/join/action'
+      - 'Microsoft.Network/natGateways/join/action'
       - 'Microsoft.Network/virtualNetworks/subnets/read'
       - 'Microsoft.Network/virtualNetworks/subnets/write'
       - 'Microsoft.Storage/storageAccounts/delete'

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -29,6 +29,9 @@ spec:
       - 'Microsoft.Storage/storageAccounts/listKeys/action'
       - 'Microsoft.Storage/storageAccounts/read'
       - 'Microsoft.Storage/storageAccounts/write'
+      - 'Microsoft.Network/serviceEndpointPolicies/join/action'
+      - 'Microsoft.Network/networkIntentPolicies/join/action'
+      - 'Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action'
   secretRef:
     name: azure-file-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
According to linked access checks in Azure, if the user has configured a nat gateway on their subnet, the network resource provider will also check for Microsoft.Network/natGateways/join/action when FSO attempts to execute a Microsoft.Network/virtualNetworks/subnets/write operation. Since the FSO credentialsrequest requires Microsoft.Network/virtualNetworks/subnets/write, and many users also bring a nat gateway, Microsoft.Network/natGateways/join/action is also required.