### PR TITLE
OCPBUGS-54760: Replace deprecated `node-role` toleration/nodeSelector

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -56,7 +56,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
         - key: hypershift.openshift.io/control-plane

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -133,7 +133,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: hypershift.openshift.io/control-plane
         operator: Exists

--- a/assets/csidriveroperators/aws-ebs/standalone/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/deployment.patch.yaml
@@ -9,10 +9,10 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -67,7 +67,7 @@ spec:
         - mountPath: /tmp
           name: tmp
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -78,7 +78,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - emptyDir:

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
@@ -36,7 +36,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
         - key: hypershift.openshift.io/control-plane

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -111,7 +111,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: hypershift.openshift.io/control-plane
         operator: Exists

--- a/assets/csidriveroperators/azure-disk/standalone/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/deployment.patch.yaml
@@ -7,10 +7,10 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"

--- a/assets/csidriveroperators/azure-disk/standalone/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -67,7 +67,7 @@ spec:
         - mountPath: /tmp
           name: tmp
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -78,7 +78,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - emptyDir:

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
@@ -52,7 +52,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
         - key: hypershift.openshift.io/control-plane

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -111,7 +111,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: hypershift.openshift.io/control-plane
         operator: Exists

--- a/assets/csidriveroperators/azure-file/standalone/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/deployment.patch.yaml
@@ -6,11 +6,11 @@ spec:
   template:
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"

--- a/assets/csidriveroperators/azure-file/standalone/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -67,7 +67,7 @@ spec:
         - mountPath: /tmp
           name: tmp
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -78,7 +78,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - emptyDir:

--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -64,11 +64,11 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: gcp-pd-csi-driver-operator
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       securityContext:

--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -64,11 +64,11 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: ibm-vpc-block-csi-driver-operator
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       securityContext:

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
@@ -36,7 +36,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
         - key: hypershift.openshift.io/control-plane

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -110,7 +110,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: hypershift.openshift.io/control-plane
         operator: Exists

--- a/assets/csidriveroperators/openstack-cinder/standalone/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-cinder/standalone/deployment.patch.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"

--- a/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -68,7 +68,7 @@ spec:
         - mountPath: /tmp
           name: tmp
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -79,7 +79,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
@@ -36,7 +36,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
         - key: hypershift.openshift.io/control-plane

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -111,7 +111,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - key: hypershift.openshift.io/control-plane
         operator: Exists

--- a/assets/csidriveroperators/openstack-manila/standalone/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-manila/standalone/deployment.patch.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"

--- a/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -69,7 +69,7 @@ spec:
         - mountPath: /tmp
           name: tmp
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -80,7 +80,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       volumes:
       - configMap:

--- a/assets/csidriveroperators/ovirt/07_deployment.yaml
+++ b/assets/csidriveroperators/ovirt/07_deployment.yaml
@@ -22,11 +22,11 @@ spec:
       serviceAccountName: ovirt-csi-driver-operator
       priorityClassName: system-cluster-critical
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       initContainers:

--- a/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
@@ -61,7 +61,7 @@ spec:
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
       volumes:

--- a/assets/csidriveroperators/powervs-block/standalone/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/standalone/06_deployment.yaml
@@ -60,11 +60,11 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: powervs-block-csi-driver-operator
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       securityContext:

--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -76,11 +76,11 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: vmware-vsphere-csi-driver-operator
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       volumes:

--- a/assets/vsphere_problem_detector/07_deployment.yaml
+++ b/assets/vsphere_problem_detector/07_deployment.yaml
@@ -55,11 +55,11 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: vsphere-problem-detector-operator
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
-      - key: node-role.kubernetes.io/master
+      - key: node-role.kubernetes.io/control-plane
         operator: Exists
         effect: "NoSchedule"
       volumes:

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -128,7 +128,7 @@ spec:
       serviceAccountName: cluster-storage-operator
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
+        key: node-role.kubernetes.io/control-plane
         operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/unreachable

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -21,9 +21,9 @@ spec:
         name: cluster-storage-operator
     spec:
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
-      - key: node-role.kubernetes.io/master  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
+      - key: node-role.kubernetes.io/control-plane  # Just tolerate NoSchedule taint on master node. If there are other conditions like disk-pressure etc, let's not schedule the control-plane pods onto that node.
         operator: Exists
         effect: "NoSchedule"
       - key: "node.kubernetes.io/unreachable"


### PR DESCRIPTION
The `node-role.kubernetes.io/master` annotation is deprecated in favour of `node-role.kubernetes.io/control-plane` [[1][1]] [[2][2]] and currently produces a warning when modifying resources via `oc`/`kubectl`.

```
❯ oc scale -n openshift-cluster-storage-operator deployment cluster-storage-operator --replicas 0
Warning: spec.template.spec.nodeSelector[node-role.kubernetes.io/master]: use "node-role.kubernetes.io/control-plane" instead
deployment.apps/cluster-storage-operator scaled
```

Migrate all `tolerations` and `nodeSelector` instances over. While both labels currently co-exist, we opt to update the existing label rather than append a new one since the new label has been present since 1.26. This is achieved like so:

```
❯ sed -i 's/node-role.kubernetes.io\/master/node-role.kubernetes.io\/control-plane/' \
    $(ag node-role -l --ignore generated --ignore vendor)
❯ make update
```

[1]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint
[2]: https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint
