### PR TITLE
OCPBUGS-54491: sync Azure File permissions with upstream docs

### DIFF
--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -16,10 +16,6 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     permissions:
-      - 'Microsoft.Network/networkSecurityGroups/join/action'
-      - 'Microsoft.Network/routeTables/join/action'
-      - 'Microsoft.Network/virtualNetworks/subnets/read'
-      - 'Microsoft.Network/virtualNetworks/subnets/write'
       - 'Microsoft.Storage/storageAccounts/delete'
       - 'Microsoft.Storage/storageAccounts/fileServices/read'
       - 'Microsoft.Storage/storageAccounts/fileServices/shares/delete'
@@ -28,6 +24,27 @@ spec:
       - 'Microsoft.Storage/storageAccounts/listKeys/action'
       - 'Microsoft.Storage/storageAccounts/read'
       - 'Microsoft.Storage/storageAccounts/write'
+      - 'Microsoft.Network/virtualNetworks/join/action'
+      - 'Microsoft.Network/virtualNetworks/subnets/join/action'
+      - 'Microsoft.Network/virtualNetworks/subnets/write'
+      - 'Microsoft.Network/virtualNetworks/subnets/read'
+      - 'Microsoft.Network/virtualNetworks/subnets/*/read'
+      - 'Microsoft.Network/privateEndpoints/write'
+      - 'Microsoft.Network/privateEndpoints/read'
+      - 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write'
+      - 'Microsoft.Network/privateDnsZones/write'
+      - 'Microsoft.Network/privateDnsZones/virtualNetworkLinks/write'
+      - 'Microsoft.Network/privateDnsZones/virtualNetworkLinks/read'
+      - 'Microsoft.Network/privateDnsZones/read'
+      - 'Microsoft.Network/privateDnsOperationStatuses/read'
+      - 'Microsoft.Network/locations/operations/read'
+      - 'Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action'
+      - 'Microsoft.Network/serviceEndpointPolicies/join/action'
+      - 'Microsoft.Network/natGateways/join/action'
+      - 'Microsoft.Network/networkIntentPolicies/join/action'
+      - 'Microsoft.Network/networkSecurityGroups/join/action'
+      - 'Microsoft.Network/routeTables/join/action'
+      - 'Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action'
   secretRef:
     name: azure-file-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
If users configure a storage class with `networkEndpointType: privateEndpoint` parameter CSI driver will fail to provision a volume due to missing permissions.

I've cross checked the OCPBUGS-54491 bug report with upstream documentation to see what we miss and also noticed a few more that were also missing upstream when testing the private endpoints manually. After discussing this with upstream the list was extended with the missing ones: https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/2513

This CredentialsRequest object is used when installing or upgrading cluster, by extracting it from payload and passing it to `ccoctl` which creates Azure roles with the permissions listed. This might result in granting more privileges than most users need.

Alternatively we could drop this change and only document the process, which would require additional manual step for users intending to use private endpoints.