### PR TITLE
NO-JIRA: correct cinder operator CredentialsRequest name

### DIFF
--- a/manifests/03_credentials_request_cinder.yaml
+++ b/manifests/03_credentials_request_cinder.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: openshift-cluster-csi-drivers
+  name: openstack-cinder-csi-driver-operator
   namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"


### PR DESCRIPTION
-  The cinder csi driver operator CredentialsRequest name uses `openshift-cluster-csi-drivers` seems a bit mislead, correct it to `openstack-cinder-csi-driver-operator` which is more clear which operator uses it.