### PR TITLE
NO-JIRA: Update openstack approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,8 +2,8 @@
 
 aliases:
   openstack-approvers:
-  - EmilienM
   - mandre
+  - stephenfin
   openshift-storage-maintainers:
   - jsafrane
   - tsmetana


### PR DESCRIPTION
Emilien is changing teams. Proposing Stephen as the co-maintainer for OpenStack.