### PR TITLE
OCPBUGS-44128: OCPBUGS-44127: Sync azure permissions

### DIFF
--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -15,14 +15,35 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     permissions:
-      - 'Microsoft.Compute/disks/*'
-      - 'Microsoft.Compute/snapshots/*'
-      - 'Microsoft.Compute/virtualMachineScaleSets/*/read'
-      - 'Microsoft.Compute/virtualMachineScaleSets/read'
-      - 'Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write'
-      - 'Microsoft.Compute/virtualMachines/*/read'
-      - 'Microsoft.Compute/virtualMachines/write'
-      - 'Microsoft.Resources/subscriptions/resourceGroups/read'
+      - Microsoft.Compute/disks/read
+      - Microsoft.Compute/disks/write
+      - Microsoft.Compute/disks/delete
+      - Microsoft.Compute/diskEncryptionSets/read
+      - Microsoft.Compute/snapshots/read
+      - Microsoft.Compute/snapshots/write
+      - Microsoft.Compute/snapshots/delete
+      - Microsoft.Compute/virtualMachines/write
+      - Microsoft.Compute/virtualMachines/read
+      - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write
+      - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read
+      - Microsoft.Compute/virtualMachineScaleSets/read
+      - Microsoft.Compute/locations/operations/read
+      - Microsoft.Compute/locations/DiskOperations/read
+      - Microsoft.Resources/subscriptions/resourceGroups/read
+      - Microsoft.Resources/subscriptions/resourceGroups/*/read
+      # Those are needed only when the virtualMachine or virtualMachineScaleSets have these additional resources configured:
+      - Microsoft.Compute/disks/beginGetAccess/action
+      - Microsoft.KeyVault/vaults/deploy/action
+      - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
+      - Microsoft.Network/applicationGateways/backendAddressPools/join/action
+      - Microsoft.Network/applicationSecurityGroups/joinIpConfiguration/action
+      - Microsoft.Network/loadBalancers/backendAddressPools/join/action
+      - Microsoft.Network/loadBalancers/inboundNatPools/join/action
+      - Microsoft.Network/loadBalancers/probes/join/action
+      - Microsoft.Network/networkInterfaces/join/action
+      - Microsoft.Network/networkSecurityGroups/join/action
+      - Microsoft.Network/publicIPPrefixes/join/action
+      - Microsoft.Network/virtualNetworks/subnets/join/action
   secretRef:
     name: azure-disk-credentials
     namespace: openshift-cluster-csi-drivers

--- a/manifests/03_credentials_request_azure_file.yaml
+++ b/manifests/03_credentials_request_azure_file.yaml
@@ -16,14 +16,11 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     permissions:
-      - 'Microsoft.Storage/storageAccounts/delete'
-      - 'Microsoft.Storage/storageAccounts/fileServices/read'
-      - 'Microsoft.Storage/storageAccounts/fileServices/shares/delete'
-      - 'Microsoft.Storage/storageAccounts/fileServices/shares/read'
-      - 'Microsoft.Storage/storageAccounts/fileServices/shares/write'
-      - 'Microsoft.Storage/storageAccounts/listKeys/action'
       - 'Microsoft.Storage/storageAccounts/read'
       - 'Microsoft.Storage/storageAccounts/write'
+      - 'Microsoft.Storage/storageAccounts/listKeys/action'
+      - 'Microsoft.Storage/operations/read'
+      # this is only necessary if the driver creates the storage account with a private endpoint:
       - 'Microsoft.Network/virtualNetworks/join/action'
       - 'Microsoft.Network/virtualNetworks/subnets/join/action'
       - 'Microsoft.Network/virtualNetworks/subnets/write'
@@ -40,12 +37,19 @@ spec:
       - 'Microsoft.Network/privateDnsOperationStatuses/read'
       - 'Microsoft.Network/locations/operations/read'
       - 'Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action'
+      # this is only necessary if the subnet carrying the write permission has these additional resources configured:
       - 'Microsoft.Network/serviceEndpointPolicies/join/action'
       - 'Microsoft.Network/natGateways/join/action'
       - 'Microsoft.Network/networkIntentPolicies/join/action'
       - 'Microsoft.Network/networkSecurityGroups/join/action'
       - 'Microsoft.Network/routeTables/join/action'
       - 'Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action'
+      # OCP carry: those are not listed upstream
+      - 'Microsoft.Storage/storageAccounts/fileServices/read'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/delete'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/read'
+      - 'Microsoft.Storage/storageAccounts/fileServices/shares/write'
+
   secretRef:
     name: azure-file-credentials
     namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
Sync Azure CSI driver permissions with upstream versions that we have in OCP 4.19:

https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md?plain=1

https://github.com/kubernetes-sigs/azurefile-csi-driver/blob/v1.33.0/docs/driver-parameters.md?plain=1


AzureDisk file diff upstream and this PR :
```diff
 - Microsoft.Compute/diskEncryptionSets/read
 - Microsoft.Compute/disks/beginGetAccess/action
 - Microsoft.Compute/disks/delete
 - Microsoft.Compute/disks/read
 - Microsoft.Compute/disks/write
 - Microsoft.Compute/locations/DiskOperations/read
 - Microsoft.Compute/locations/operations/read
 - Microsoft.Compute/snapshots/delete
 - Microsoft.Compute/snapshots/read
 - Microsoft.Compute/snapshots/write
 - Microsoft.Compute/virtualMachineScaleSets/read
 - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read
 - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write
 - Microsoft.Compute/virtualMachines/read
 - Microsoft.Compute/virtualMachines/write
 - Microsoft.KeyVault/vaults/deploy/action
 - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
 - Microsoft.Network/applicationGateways/backendAddressPools/join/action
 - Microsoft.Network/applicationSecurityGroups/joinIpConfiguration/action
 - Microsoft.Network/loadBalancers/backendAddressPools/join/action
 - Microsoft.Network/loadBalancers/inboundNatPools/join/action
 - Microsoft.Network/loadBalancers/probes/join/action
 - Microsoft.Network/networkInterfaces/join/action
 - Microsoft.Network/networkSecurityGroups/join/action
 - Microsoft.Network/publicIPPrefixes/join/action
 - Microsoft.Network/virtualNetworks/subnets/join/action
-- Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/*/read
-- Microsoft.Resources/subscriptions/resourceGroups/Microsoft.Compute/read
+- Microsoft.Resources/subscriptions/resourceGroups/*/read
+- Microsoft.Resources/subscriptions/resourceGroups/read
```

AzureDisk diff with today's OCP, with `*` expanded:
```diff
+"Microsoft.Compute/diskEncryptionSets/read"
 "Microsoft.Compute/disks/beginGetAccess/action"
 "Microsoft.Compute/disks/delete"
-"Microsoft.Compute/disks/endGetAccess/action"
 "Microsoft.Compute/disks/read"
 "Microsoft.Compute/disks/write"
-"Microsoft.Compute/snapshots/beginGetAccess/action"
+"Microsoft.Compute/locations/diskOperations/read"
+"Microsoft.Compute/locations/operations/read"
 "Microsoft.Compute/snapshots/delete"
-"Microsoft.Compute/snapshots/endGetAccess/action"
 "Microsoft.Compute/snapshots/read"
 "Microsoft.Compute/snapshots/write"
-"Microsoft.Compute/virtualMachineScaleSets/extensions/read"
-"Microsoft.Compute/virtualMachineScaleSets/extensions/roles/read"
-"Microsoft.Compute/virtualMachineScaleSets/instanceView/read"
-"Microsoft.Compute/virtualMachineScaleSets/networkInterfaces/read"
-"Microsoft.Compute/virtualMachineScaleSets/osUpgradeHistory/read"
-"Microsoft.Compute/virtualMachineScaleSets/providers/Microsoft.Insights/diagnosticSettings/read"
-"Microsoft.Compute/virtualMachineScaleSets/providers/Microsoft.Insights/logDefinitions/read"
-"Microsoft.Compute/virtualMachineScaleSets/providers/Microsoft.Insights/metricDefinitions/read"
-"Microsoft.Compute/virtualMachineScaleSets/publicIPAddresses/read"
 "Microsoft.Compute/virtualMachineScaleSets/read"
-"Microsoft.Compute/virtualMachineScaleSets/rollingUpgrades/read"
-"Microsoft.Compute/virtualMachineScaleSets/skus/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/extensions/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/instanceView/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipConfigurations/publicIPAddresses/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/ipConfigurations/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/networkInterfaces/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read"
 "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read"
-"Microsoft.Compute/virtualMachineScaleSets/virtualMachines/runCommands/read"
 "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write"
-"Microsoft.Compute/virtualMachineScaleSets/vmSizes/read"
-"Microsoft.Compute/virtualMachines/extensions/read"
-"Microsoft.Compute/virtualMachines/instanceView/read"
-"Microsoft.Compute/virtualMachines/patchAssessmentResults/latest/read"
-"Microsoft.Compute/virtualMachines/patchAssessmentResults/latest/softwarePatches/read"
-"Microsoft.Compute/virtualMachines/patchInstallationResults/read"
-"Microsoft.Compute/virtualMachines/patchInstallationResults/softwarePatches/read"
-"Microsoft.Compute/virtualMachines/providers/Microsoft.Insights/diagnosticSettings/read"
-"Microsoft.Compute/virtualMachines/providers/Microsoft.Insights/logDefinitions/read"
-"Microsoft.Compute/virtualMachines/providers/Microsoft.Insights/metricDefinitions/read"
 "Microsoft.Compute/virtualMachines/read"
-"Microsoft.Compute/virtualMachines/runCommands/read"
-"Microsoft.Compute/virtualMachines/vmSizes/read"
 "Microsoft.Compute/virtualMachines/write"
+"Microsoft.KeyVault/vaults/deploy/action"
+"Microsoft.ManagedIdentity/userAssignedIdentities/assign/action"
+"Microsoft.Network/applicationGateways/backendAddressPools/join/action"
+"Microsoft.Network/applicationSecurityGroups/joinIpConfiguration/action"
+"Microsoft.Network/loadBalancers/backendAddressPools/join/action"
+"Microsoft.Network/loadBalancers/inboundNatPools/join/action"
+"Microsoft.Network/loadBalancers/probes/join/action"
+"Microsoft.Network/networkInterfaces/join/action"
+"Microsoft.Network/networkSecurityGroups/join/action"
+"Microsoft.Network/publicIPPrefixes/join/action"
+"Microsoft.Network/virtualNetworks/subnets/join/action"
+"Microsoft.Resources/subscriptions/resourcegroups/deployments/operations/read"
+"Microsoft.Resources/subscriptions/resourcegroups/deployments/operationstatuses/read"
+"Microsoft.Resources/subscriptions/resourcegroups/deployments/read"
 "Microsoft.Resources/subscriptions/resourceGroups/read"
+"Microsoft.Resources/subscriptions/resourcegroups/resources/read"
```

AzureDisk diff between [current ARO role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/containers#azure-red-hat-openshift-disk-storage-operator) and this PR (i.e. this PR has more permissions):
```diff
 - Microsoft.Compute/diskEncryptionSets/read
 - Microsoft.Compute/disks/beginGetAccess/action
 - Microsoft.Compute/disks/delete
 - Microsoft.Compute/disks/read
 - Microsoft.Compute/disks/write
 - Microsoft.Compute/locations/DiskOperations/read
 - Microsoft.Compute/locations/operations/read
 - Microsoft.Compute/snapshots/delete
 - Microsoft.Compute/snapshots/read
 - Microsoft.Compute/snapshots/write
 - Microsoft.Compute/virtualMachineScaleSets/read
 - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read
 - Microsoft.Compute/virtualMachineScaleSets/virtualMachines/write
 - Microsoft.Compute/virtualMachines/read
 - Microsoft.Compute/virtualMachines/write
+- Microsoft.KeyVault/vaults/deploy/action
+- Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
+- Microsoft.Network/applicationGateways/backendAddressPools/join/action
+- Microsoft.Network/applicationSecurityGroups/joinIpConfiguration/action
+- Microsoft.Network/loadBalancers/backendAddressPools/join/action
+- Microsoft.Network/loadBalancers/inboundNatPools/join/action
+- Microsoft.Network/loadBalancers/probes/join/action
+- Microsoft.Network/networkInterfaces/join/action
+- Microsoft.Network/networkSecurityGroups/join/action
+- Microsoft.Network/publicIPPrefixes/join/action
+- Microsoft.Network/virtualNetworks/subnets/join/action
+- Microsoft.Resources/subscriptions/resourceGroups/*/read
 - Microsoft.Resources/subscriptions/resourceGroups/read

```

AzureFile file diff  between upstream and this PR:
```diff
 - Microsoft.Network/locations/operations/read
 - Microsoft.Network/natGateways/join/action
 - Microsoft.Network/networkIntentPolicies/join/action
 - Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action
 - Microsoft.Network/networkSecurityGroups/join/action
 - Microsoft.Network/privateDnsOperationStatuses/read
 - Microsoft.Network/privateDnsZones/join/action
 - Microsoft.Network/privateDnsZones/read
 - Microsoft.Network/privateDnsZones/virtualNetworkLinks/read
 - Microsoft.Network/privateDnsZones/virtualNetworkLinks/write
 - Microsoft.Network/privateDnsZones/write
 - Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read
 - Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write
 - Microsoft.Network/privateEndpoints/read
 - Microsoft.Network/privateEndpoints/write
 - Microsoft.Network/routeTables/join/action
 - Microsoft.Network/serviceEndpointPolicies/join/action
 - Microsoft.Network/virtualNetworks/join/action
 - Microsoft.Network/virtualNetworks/subnets/join/action
 - Microsoft.Network/virtualNetworks/subnets/read
 - Microsoft.Network/virtualNetworks/subnets/write
 - Microsoft.Storage/operations/read
+- Microsoft.Storage/storageAccounts/fileServices/read
+- Microsoft.Storage/storageAccounts/fileServices/shares/delete
+- Microsoft.Storage/storageAccounts/fileServices/shares/read
+- Microsoft.Storage/storageAccounts/fileServices/shares/write
 - Microsoft.Storage/storageAccounts/listKeys/action
 - Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action
 - Microsoft.Storage/storageAccounts/read
 - Microsoft.Storage/storageAccounts/write
```

AzureFile diff with today's OCP, with `*` expanded:
```diff
 "Microsoft.Network/locations/operations/read"
 "Microsoft.Network/natGateways/join/action"
 "Microsoft.Network/networkIntentPolicies/join/action"
 "Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action"
 "Microsoft.Network/networkSecurityGroups/join/action"
 "Microsoft.Network/privateDnsOperationStatuses/read"
 "Microsoft.Network/privateDnsZones/join/action"
 "Microsoft.Network/privateDnsZones/read"
 "Microsoft.Network/privateDnsZones/virtualNetworkLinks/read"
 "Microsoft.Network/privateDnsZones/virtualNetworkLinks/write"
 "Microsoft.Network/privateDnsZones/write"
 "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read"
 "Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write"
 "Microsoft.Network/privateEndpoints/read"
 "Microsoft.Network/privateEndpoints/write"
 "Microsoft.Network/routeTables/join/action"
 "Microsoft.Network/serviceEndpointPolicies/join/action"
 "Microsoft.Network/virtualNetworks/join/action"
 "Microsoft.Network/virtualNetworks/subnets/join/action"
 "Microsoft.Network/virtualNetworks/subnets/read"
 "Microsoft.Network/virtualNetworks/subnets/write"
-"Microsoft.Storage/storageAccounts/delete"
+"Microsoft.Storage/operations/read"
 "Microsoft.Storage/storageAccounts/fileServices/read"
 "Microsoft.Storage/storageAccounts/fileServices/shares/delete"
 "Microsoft.Storage/storageAccounts/fileServices/shares/read"
 "Microsoft.Storage/storageAccounts/fileServices/shares/write"
 "Microsoft.Storage/storageAccounts/listkeys/action"
 "Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action"
 "Microsoft.Storage/storageAccounts/read"
 "Microsoft.Storage/storageAccounts/write"
```

AzureFile diff between [current ARO role](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/containers#azure-red-hat-openshift-file-storage-operator) and this PR (i.e. this PR has more permissions)
```diff
+- Microsoft.Network/locations/operations/read
 - Microsoft.Network/natGateways/join/action
+- Microsoft.Network/networkIntentPolicies/join/action
+- Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action
 - Microsoft.Network/networkSecurityGroups/join/action
+- Microsoft.Network/privateDnsOperationStatuses/read
+- Microsoft.Network/privateDnsZones/join/action
+- Microsoft.Network/privateDnsZones/read
+- Microsoft.Network/privateDnsZones/virtualNetworkLinks/read
+- Microsoft.Network/privateDnsZones/virtualNetworkLinks/write
+- Microsoft.Network/privateDnsZones/write
+- Microsoft.Network/privateEndpoints/privateDnsZoneGroups/read
+- Microsoft.Network/privateEndpoints/privateDnsZoneGroups/write
+- Microsoft.Network/privateEndpoints/read
+- Microsoft.Network/privateEndpoints/write
 - Microsoft.Network/routeTables/join/action
+- Microsoft.Network/serviceEndpointPolicies/join/action
+- Microsoft.Network/virtualNetworks/join/action
+- Microsoft.Network/virtualNetworks/subnets/join/action
 - Microsoft.Network/virtualNetworks/subnets/read
 - Microsoft.Network/virtualNetworks/subnets/write
-- Microsoft.Storage/storageAccounts/delete
+- Microsoft.Storage/operations/read
 - Microsoft.Storage/storageAccounts/fileServices/read
 - Microsoft.Storage/storageAccounts/fileServices/shares/delete
 - Microsoft.Storage/storageAccounts/fileServices/shares/read
 - Microsoft.Storage/storageAccounts/fileServices/shares/write
 - Microsoft.Storage/storageAccounts/listKeys/action
+- Microsoft.Storage/storageAccounts/listKeys/action
+- Microsoft.Storage/storageAccounts/PrivateEndpointConnectionsApproval/action
 - Microsoft.Storage/storageAccounts/read
 - Microsoft.Storage/storageAccounts/write
```
