### PR TITLE
OCPBUGS-56201: improve message template for PodStartupStorageOperationsFailing alert

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -47,11 +47,18 @@ spec:
         labels:
           severity: info
         annotations:
-          summary: "Pods can't start because {{ $labels.operation_name }} of volume plugin {{ $labels.volume_plugin }} is permanently failing on node {{ $labels.node }}."
+          summary: "Pods can't start because {{ $labels.operation_name }} of volume plugin {{ $labels.volume_plugin }} is permanently failing{{ if $labels.node }} on node {{ $labels.node }}{{ end }}."
           description: |
-            Failing storage operation "{{ $labels.operation_name }}" of volume plugin {{ $labels.volume_plugin }} was preventing Pods on node {{ $labels.node }}
+            Failing storage operation "{{ $labels.operation_name }}" of volume plugin {{ $labels.volume_plugin }} was preventing Pods{{ if $labels.node }} on node {{ $labels.node }}{{ end }}
             from starting for past 5 minutes.
+            {{ if eq $labels.operation_name "volume_mount" -}}
             Please investigate Pods that are "ContainerCreating" on the node: "oc get pod --field-selector=spec.nodeName={{ $labels.node }} --all-namespaces | grep ContainerCreating".
+            {{- else if eq $labels.operation_name "volume_attach" -}}
+            Please investigate Pods that are "ContainerCreating" across all nodes: "oc get pod --all-namespaces | grep ContainerCreating".
+            Check volume attachment status: "oc get volumeattachment" and controller manager logs.
+            {{- else -}}
+            Please investigate Pods that are "ContainerCreating"{{ if $labels.node }} on node {{ $labels.node }}{{ end }}.
+            {{- end }}
             Events of the Pods should contain exact error message: "oc describe pod -n <pod namespace> <pod name>".
 
     - name: storage-selinux.rules


### PR DESCRIPTION
Node label is not part of the metric itself but appended during metric collection by Prometheus. It can be opted-in which is currently the case for volume mount metrics in kubelet:

```
oc -n openshift-monitoring get servicemonitor/kubelet -o yaml | grep -A 1 -B 1 attachMetadata
spec:
  attachMetadata:
    node: true
```

However, volume attachment metrics don't opt-in for this label metadata most likely because they're produced by KCM which can run on different node instead of the one where volume is being attached. That means we should not add it as it would produce confusing messages.

Instead we can improve the template for this alert to avoid displaying messages with missing nodeName.

## Before fix:

See the missing node name in `--field-selector=spec.nodeName=` 

<img width="2278" alt="Screenshot 2025-05-28 at 11 15 20" src="https://github.com/user-attachments/assets/89b84bcf-3795-480b-88cb-316546ac0c28" />


## After fix:
<img width="2278" alt="Screenshot 2025-05-28 at 11 55 56" src="https://github.com/user-attachments/assets/ef47dd80-ffb9-435c-9ebc-dd786585198d" />
