### PR TITLE
STOR-2340: Network Policies for Cluster Storage Operator

### DIFF
--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -15,6 +15,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.operator-metrics-range: allow
     spec:
       containers:
       - args:

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -20,6 +20,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.operator-metrics-range: allow
     spec:
       containers:
       - args:

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -19,6 +19,9 @@ spec:
         openshift.io/required-scc: nonroot-v2
       labels:
         name: cluster-storage-operator
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.operator-metrics-range: allow
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2340

This subscribes pods in the openshift-cluster-storage-operator namespace to the required network policies defined in https://github.com/openshift/cluster-storage-operator/pull/579/files

/cc @openshift/storage @mpatlasov
