### PR TITLE
WIP: Network Policy "Deny-All" for cluster-storage-operator namespace

### DIFF
--- a/manifests/09_network-policy-deny-all.yaml
+++ b/manifests/09_network-policy-deny-all.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cluster-storage-operator
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Storage
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
Let's see CI for https://github.com/openshift/cluster-storage-operator/pull/589 and https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/238 when combined with deny-all in openshift-cluster-storage-operator namespace.