### PR TITLE
STOR-1064: add volume-data-source-validator controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ export SNAPSHOTTER_IMAGE=quay.io/openshift/origin-csi-external-snapshotter:lates
 export NODE_DRIVER_REGISTRAR_IMAGE=quay.io/openshift/origin-csi-node-driver-registrar:latest  
 export LIVENESS_PROBE_IMAGE=quay.io/openshift/origin-csi-livenessprobe:latest  
 export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest  
+export VOLUME_DATA_SOURCE_VALIDATOR_IMAGE=quay.io/openshift/origin-volume-data-source-validator:latest
 ```
 
 #### Configure provider specific variables

--- a/assets/volumedatasourcevalidator/01_serviceaccount.yaml
+++ b/assets/volumedatasourcevalidator/01_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: volume-data-source-validator
+  namespace: openshift-cluster-storage-operator

--- a/assets/volumedatasourcevalidator/02_clusterrole.yaml
+++ b/assets/volumedatasourcevalidator/02_clusterrole.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: volume-data-source-validator
+rules:
+  - apiGroups: [populator.storage.k8s.io]
+    resources: [volumepopulators]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, watch]
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [list, watch, create, update, patch]
+  - apiGroups: [coordination.k8s.io]
+    resources: [leases]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [authentication.k8s.io]
+    resources: [tokenreviews]
+    verbs: [create]

--- a/assets/volumedatasourcevalidator/03_clusterrolebinding.yaml
+++ b/assets/volumedatasourcevalidator/03_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: volume-data-source-validator
+subjects:
+  - kind: ServiceAccount
+    name: volume-data-source-validator
+    namespace: openshift-cluster-storage-operator
+roleRef:
+  kind: ClusterRole
+  name: volume-data-source-validator
+  apiGroup: rbac.authorization.k8s.io

--- a/assets/volumedatasourcevalidator/04_deployment.yaml
+++ b/assets/volumedatasourcevalidator/04_deployment.yaml
@@ -1,0 +1,54 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: volume-data-source-validator
+  namespace: openshift-cluster-storage-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: volume-data-source-validator
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
+      labels:
+        name: volume-data-source-validator
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.api-server: allow
+
+    spec:
+      serviceAccountName: volume-data-source-validator
+      containers:
+        - name: volume-data-source-validator
+          image: ${VOLUME_DATA_SOURCE_VALIDATOR_IMAGE}
+          args:
+            - "--v=${LOG_LEVEL}"
+            - "--http-endpoint=127.0.0.1:8443"
+            - "--leader-election=true"
+            - "--leader-election-lease-duration=${LEADER_ELECTION_LEASE_DURATION}"
+            - "--leader-election-renew-deadline=${LEADER_ELECTION_RENEW_DEADLINE}"
+            - "--leader-election-retry-period=${LEADER_ELECTION_RETRY_PERIOD}"
+            - "--leader-election-namespace=openshift-cluster-storage-operator"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8443
+              name: validator-http
+              protocol: TCP
+          resources:
+            requests:
+              memory: 50Mi
+              cpu: 10m
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          terminationMessagePolicy: FallbackToLogsOnError
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/assets/volumedatasourcevalidator/07_volumedatasourcevalidator_crd.yaml
+++ b/assets/volumedatasourcevalidator/07_volumedatasourcevalidator_crd.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: https://github.com/kubernetes/enhancements/pull/2934
+  name: volumepopulators.populator.storage.k8s.io
+spec:
+  group: populator.storage.k8s.io
+  names:
+    kind: VolumePopulator
+    listKind: VolumePopulatorList
+    plural: volumepopulators
+    singular: volumepopulator
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .sourceKind
+          name: SourceKind
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: VolumePopulator represents the registration for a volume populator. VolumePopulators are cluster scoped.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            sourceKind:
+              description: Kind of the data source this populator supports
+              properties:
+                group:
+                  type: string
+                kind:
+                  type: string
+              required:
+                - group
+                - kind
+              type: object
+          required:
+            - sourceKind
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -112,6 +112,8 @@ spec:
           value: quay.io/openshift/origin-csi-driver-manila-operator:latest
         - name: KUBE_RBAC_PROXY_CONTROL_PLANE_IMAGE
           value: quay.io/openshift/origin-kube-rbac-proxy:latest
+        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+          value: quay.io/openshift/origin-volume-data-source-validator:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -100,6 +100,8 @@ spec:
           value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
         - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE
           value: quay.io/openshift/origin-powervs-block-csi-driver:latest
+        - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+          value: quay.io/openshift/origin-volume-data-source-validator:latest
         - name: TOOLS_IMAGE
           value: quay.io/openshift/origin-tools:latest
         image: quay.io/openshift/origin-cluster-storage-operator:latest

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -130,6 +130,8 @@ spec:
             value: quay.io/openshift/origin-powervs-block-csi-driver-operator:latest
           - name: POWERVS_BLOCK_CSI_DRIVER_IMAGE
             value: quay.io/openshift/origin-powervs-block-csi-driver:latest
+          - name: VOLUME_DATA_SOURCE_VALIDATOR_IMAGE
+            value: quay.io/openshift/origin-volume-data-source-validator:latest
           - name: TOOLS_IMAGE
             value: quay.io/openshift/origin-tools:latest
           resources:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -134,3 +134,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-tools:latest
+  - name: volume-data-source-validator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-volume-data-source-validator:latest

--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/defaultstorageclass"
+	"github.com/openshift/cluster-storage-operator/pkg/operator/volumedatasourcevalidator"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/vsphereproblemdetector"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -93,6 +94,12 @@ func (csr *commonStarter) CreateCommonControllers() error {
 		csr.eventRecorder,
 	)
 	csr.controllers = append(csr.controllers, storageClassController)
+
+	volumeDataSourceValidatorController := volumedatasourcevalidator.NewController(
+		csr.commonClients,
+		csr.eventRecorder,
+	)
+	csr.controllers = append(csr.controllers, volumeDataSourceValidatorController)
 
 	relatedObjects := []configv1.ObjectReference{
 		{Resource: "namespaces", Name: operatorNamespace},

--- a/pkg/operator/volumedatasourcevalidator/controller.go
+++ b/pkg/operator/volumedatasourcevalidator/controller.go
@@ -1,0 +1,141 @@
+package volumedatasourcevalidator
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/library-go/pkg/config/leaderelection"
+	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
+	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
+
+	operatorapi "github.com/openshift/api/operator/v1"
+	"github.com/openshift/cluster-storage-operator/assets"
+	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/controller/manager"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/loglevel"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/staticresourcecontroller"
+	"github.com/openshift/library-go/pkg/operator/status"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+)
+
+const (
+	volumeDataSourceValidatorOperatorImage = "VOLUME_DATA_SOURCE_VALIDATOR_IMAGE"
+)
+
+// VolumeDataSourceValidatorStarter is a controller that deploys the volume-data-source-validator
+// which validates dataSourceRef field in PersistentVolumeClaims.
+type VolumeDataSourceValidatorStarter struct {
+	controller     manager.ControllerManager
+	operatorClient v1helpers.OperatorClient
+	versionGetter  status.VersionGetter
+	targetVersion  string
+	eventRecorder  events.Recorder
+	running        bool
+}
+
+func NewController(
+	clients *csoclients.Clients,
+	eventRecorder events.Recorder) factory.Controller {
+	c := &VolumeDataSourceValidatorStarter{
+		operatorClient: clients.OperatorClient,
+		eventRecorder:  eventRecorder.WithComponentSuffix("VolumeDataSourceValidatorStarter"),
+	}
+
+	c.controller = c.createVolumeDataSourceValidatorManager(clients)
+	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(clients.OperatorClient).WithInformers(
+		clients.OperatorClient.Informer(),
+	).ToController("VolumeDataSourceValidatorStarter", eventRecorder)
+}
+
+func (c *VolumeDataSourceValidatorStarter) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	klog.V(4).Infof("VolumeDataSourceValidatorStarter.Sync started")
+	defer klog.V(4).Infof("VolumeDataSourceValidatorStarter.Sync finished")
+
+	opSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if opSpec.ManagementState != operatorapi.Managed {
+		return nil
+	}
+
+	// Always deploy the volume data source validator. It's a standard Kubernetes component
+	// required for PVC data source functionality
+	if !c.running {
+		go c.controller.Start(ctx)
+		c.running = true
+	}
+	return nil
+}
+
+func (c *VolumeDataSourceValidatorStarter) createVolumeDataSourceValidatorManager(
+	clients *csoclients.Clients) manager.ControllerManager {
+	mgr := manager.NewControllerManager()
+
+	staticAssets := []string{
+		"volumedatasourcevalidator/01_serviceaccount.yaml",
+		"volumedatasourcevalidator/02_clusterrole.yaml",
+		"volumedatasourcevalidator/03_clusterrolebinding.yaml",
+		"volumedatasourcevalidator/07_volumedatasourcevalidator_crd.yaml",
+	}
+
+	volumeDataSourceValidatorName := "VolumeDataSourceValidatorStaticController"
+	mgr = mgr.WithController(staticresourcecontroller.NewStaticResourceController(
+		volumeDataSourceValidatorName,
+		assets.ReadFile,
+		staticAssets,
+		resourceapply.NewKubeClientHolder(clients.KubeClient).WithAPIExtensionsClient(clients.ExtensionClientSet),
+		c.operatorClient,
+		c.eventRecorder).AddKubeInformers(clients.KubeInformers), 1)
+
+	deploymentAssets, err := assets.ReadFile("volumedatasourcevalidator/04_deployment.yaml")
+	if err != nil {
+		panic(err)
+	}
+
+	leConfig := leaderelection.LeaderElectionDefaulting(configv1.LeaderElection{}, "default", "default")
+
+	volumeDataSourceValidatorDeploymentController, err := deploymentcontroller.NewDeploymentControllerBuilder(
+		"VolumeDataSourceValidatorDeploymentController",
+		deploymentAssets,
+		c.eventRecorder,
+		clients.OperatorClient,
+		clients.KubeClient,
+		clients.KubeInformers.InformersFor(csoclients.OperatorNamespace).Apps().V1().Deployments(),
+	).WithManifestHooks(
+		c.withReplacerHook(),
+		csidrivercontrollerservicecontroller.WithLeaderElectionReplacerHook(leConfig),
+	).WithConditions(
+		operatorapi.OperatorStatusTypeProgressing,
+		operatorapi.OperatorStatusTypeDegraded,
+	).ToController()
+
+	mgr = mgr.WithController(volumeDataSourceValidatorDeploymentController, 1)
+
+	return mgr
+}
+
+func (c *VolumeDataSourceValidatorStarter) withReplacerHook() deploymentcontroller.ManifestHookFunc {
+	return func(spec *operatorapi.OperatorSpec, deployment []byte) ([]byte, error) {
+		logLevel := loglevel.LogLevelToVerbosity(spec.LogLevel)
+		pairs := []string{
+			"${VOLUME_DATA_SOURCE_VALIDATOR_IMAGE}", os.Getenv(volumeDataSourceValidatorOperatorImage),
+			"${LOG_LEVEL}", strconv.Itoa(logLevel),
+		}
+
+		replacer := strings.NewReplacer(pairs...)
+		newDeployment := replacer.Replace(string(deployment))
+		return []byte(newDeployment), nil
+	}
+}


### PR DESCRIPTION
Adds Volume Data Source Validator controller to CSO. We're still waiting for ART [onboarding](https://issues.redhat.com/browse/ART-12958) so currently there is no validator production image available, however this PR can be tested earlier locally (if needed) with custom image built from validator [repo](https://github.com/openshift/volume-data-source-validator) and later verified with production images. This image is loaded by CSO via env. variable `VOLUME_DATA_SOURCE_VALIDATOR_IMAGE` which can point to custom image built from the validator repo.

For more details see the linked epic and enhancement doc: https://github.com/openshift/enhancements/pull/1784

cc @openshift/storage