### PR TITLE
STOR-2330: Add labels to subscribe ibm-vpc-block CSI driver operator to NPs

### DIFF
--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -18,6 +18,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: ibm-vpc-block-csi-driver-operator
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.operator-metrics-range: allow
     spec:
       containers:
       - args:


### PR DESCRIPTION
https://issues.redhat.com//browse/STOR-2330

This PR subscribes ibm-vpc-block CSI driver operator pods to NPs from https://github.com/openshift/cluster-storage-operator/pull/579