### PR TITLE
STOR-2330: Add RBAC rule to let ibm-vpc-block-csi-driver-operator manage NetworkPolicy

### DIFF
--- a/assets/csidriveroperators/ibm-vpc-block/04_role.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/04_role.yaml
@@ -65,3 +65,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update


### PR DESCRIPTION
The operator needs to manage NP "allow-ingress-to-ibm-vpc-block-metrics". See https://github.com/openshift/ibm-vpc-block-csi-driver-operator/pull/148 for details.