### PR TITLE
OCPBUGS-60064: hypershift: add app label to csdriveroperators running in HCP

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -8,6 +8,7 @@ spec:
       annotations:
         openshift.io/required-scc: restricted-v2
       labels:
+        app: aws-ebs-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -17,6 +17,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: aws-ebs-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: aws-ebs-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       labels:
+        app: azure-disk-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -18,6 +18,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: azure-disk-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: azure-disk-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       labels:
+        app: azure-file-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -18,6 +18,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: azure-file-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: azure-file-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       labels:
+        app: openstack-cinder-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -18,6 +18,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: openstack-cinder-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: openstack-cinder-csi-driver-operator
     spec:

--- a/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
@@ -15,6 +15,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: powervs-block-csi-driver-operator
         name: powervs-block-csi-driver-operator
     spec:
       containers:


### PR DESCRIPTION
HCM is looking to export logs indexed on the `app` label but some components in the HCP are missing the label.

This PR adds the `app` label to the CSI driver operators deployed on the HCP.