### PR TITLE
STOR-2523: hypershift: Signal operands version and parent operator in metadata 

### DIFF
--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/deployment.patch.yaml
@@ -7,8 +7,10 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
       labels:
         app: aws-ebs-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -13,9 +13,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: aws-ebs-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: aws-ebs-csi-driver-operator
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        release.openshift.io/version: ${RELEASE_VERSION}
       labels:
         app: azure-disk-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -15,9 +15,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: azure-disk-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: azure-disk-csi-driver-operator
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        release.openshift.io/version: ${RELEASE_VERSION}
       labels:
         app: azure-file-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
     spec:
       affinity:

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -15,9 +15,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: azure-file-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: azure-file-csi-driver-operator
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/deployment.patch.yaml
@@ -5,8 +5,11 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        release.openshift.io/version: ${RELEASE_VERSION}
       labels:
         app: openstack-cinder-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -16,9 +16,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openstack-cinder-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: openstack-cinder-csi-driver-operator
         openshift.storage.network-policy.all-egress: allow

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
@@ -5,7 +5,11 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        release.openshift.io/version: ${RELEASE_VERSION}
       labels:
+        app: manila-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -16,8 +16,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: manila-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: manila-csi-driver-operator
         openshift.storage.network-policy.all-egress: allow

--- a/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
@@ -13,9 +13,11 @@ spec:
     metadata:
       annotations:
         openshift.io/required-scc: restricted-v2
+        release.openshift.io/version: ${RELEASE_VERSION}
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: powervs-block-csi-driver-operator
+        hypershift.openshift.io/managed-by: cluster-storage-operator
         name: powervs-block-csi-driver-operator
         openshift.storage.network-policy.dns: allow
         openshift.storage.network-policy.api-server: allow

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -108,8 +108,12 @@ func (c *HyperShiftDeploymentController) Sync(ctx context.Context, syncCtx facto
 
 	namespaceReplacer := strings.NewReplacer("${CONTROLPLANE_NAMESPACE}", c.controlNamespace)
 	hyperShiftImageReplacer := strings.NewReplacer("${HYPERSHIFT_IMAGE}", envHyperShiftImage)
-	replacers = append(replacers, namespaceReplacer)
-	replacers = append(replacers, hyperShiftImageReplacer)
+	releaseVersionReplacer := strings.NewReplacer("${RELEASE_VERSION}", c.targetVersion)
+	replacers = append(replacers,
+		namespaceReplacer,
+		hyperShiftImageReplacer,
+		releaseVersionReplacer,
+	)
 
 	nodeSelector, err := c.getHostedControlPlaneNodeSelector()
 	if err != nil {


### PR DESCRIPTION
Signal rollout to a new version is completed for operands running management side

Adds the release.openshift.io/version annotation to CSI driver operand deployments on the management side. This annotation enables HyperShift to track version rollouts and signal when deployment to a new version is completed. Also adds the hypershift.openshift.io/managed-by label to identify operands managed by this operator.