### PR TITLE
STOR-2463: add csi-external-snapshot-metadata to image-references

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -62,6 +62,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-csi-external-resizer:latest
+  - name: csi-external-snapshot-metadata
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-csi-external-snapshot-metadata:latest
   - name: csi-external-snapshotter
     from:
       kind: DockerImage


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2463

Add csi-external-shapshot-metadata to image-references so it shows up in the release payload ([docs](https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release)).

/hold for https://github.com/openshift/release/pull/68235 to pass ci/prow/okd-scos-images
/cc @openshift/storage
