### PR TITLE
OCPBUGS-60948: Rename the SELinuxMount metric to :count

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -78,7 +78,7 @@ spec:
       # Number of conflicts reported by the SELinux warning controller, i.e. pods that may conflict, if they land on the same node.
       # The controller does not emit metrics with other properties than "SELinuxLabel" or "SELinuxChangePolicy". Still, let's filter them to be future proof and keep the cardinality low.
       - expr: sum by(property) (selinux_warning_controller_selinux_volume_conflict{property =~ "SELinuxLabel|SELinuxChangePolicy"})
-        record: cluster:selinux_warning_controller_selinux_volume_conflict:total
+        record: cluster:selinux_warning_controller_selinux_volume_conflict:count
     - name: kubernetes-storage
     # These alerts originate from https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/de834e9a291b49396125768f041e2078763f48b5/alerts/storage_alerts.libsonnet
       rules:


### PR DESCRIPTION
`:total` suffix is reserved to counter and this is not a counter. `:count` was suggested in [telemetry configuration review](https://github.com/openshift/cluster-monitoring-operator/pull/2653).