### PR TITLE
SPLAT-2467: Updated VPD alerts to reflect current vSphere support

### DIFF
--- a/assets/vsphere_problem_detector/12_prometheusrules.yaml
+++ b/assets/vsphere_problem_detector/12_prometheusrules.yaml
@@ -107,17 +107,30 @@ spec:
 
       - alert: VSphereOlderVCenterPresent
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
-        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the the alerting rule.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the alerting rule.
         expr: |
-          min_over_time(vsphere_vcenter_info{api_version=~"^7\\.0\\.[0-1].*|^6.*"}[5m]) > 0
+          min_over_time(vsphere_vcenter_info{api_version=~"^7.*|^6.*"}[5m]) > 0
         for: 10m
         labels:
           severity: info
         annotations:
-          summary: "Detected vSphere vCenter version less than 7.0.2 in Openshift cluster."
+          summary: "Detected vSphere vCenter version less than 8 in Openshift cluster."
           description: |
-            The cluster is using vCenter version less than 7.0.2, which is being deprecated by Openshift. A future version of
-            Openshift will remove support for vCenter versions lest than 7.0.2 and it is recommended to update your vCenter to the latest version.
+            The cluster is using vCenter version less than 8, which is being deprecated by Openshift. A future version of
+            Openshift will remove support for vCenter versions less than 8 and it is recommended to update your vCenter to a supported version.
+
+      - alert: VSphereUnsupportedVCenterPresent
+        # Using min_over_time to make sure the metric is `1` for whole 5 minutes.
+        # A missed scraping (e.g. due to a pod restart) will result in prometheus re-evaluating the alerting rule.
+        expr: |
+          min_over_time(vsphere_vcenter_info{api_version=~"^9.*"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Detected vSphere vCenter version 9 in Openshift cluster."
+          description: |
+            The cluster is using vCenter version 9, which has not been tested by Openshift. A future version of Openshift will add support for vCenter version 9.
 
       - alert: VSphereOpenshiftVmsCBTMismatch
         # Using min_over_time to make sure the metric is `1` for whole 5 minutes.


### PR DESCRIPTION
[SPLAT-2467](https://issues.redhat.com//browse/SPLAT-2467)

### Changes
- Updated the VSphereOlderVCenterPresent alert to notify admin of any 7 and below vCenter found.  vSphere 7.x is leaving support by Broadcom later this year.
- Added new alert to notify admin if they are running on vSphere 9 which is not supported yet by OCP. 

### Notes
Once vSphere 9 support is added, the temp alert can be removed.