### PR TITLE
OCPBUGS-61175: Add RBAC rule to let manila-csi-driver-operator manage NetworkPolicy

### DIFF
--- a/assets/csidriveroperators/openstack-manila/base/05_clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-manila/base/05_clusterrole.yaml
@@ -327,3 +327,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/assets/csidriveroperators/openstack-manila/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_manila-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_manila-csi-driver-operator-clusterrole.yaml
@@ -317,3 +317,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/assets/csidriveroperators/openstack-manila/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_manila-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/openstack-manila/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_manila-csi-driver-operator-clusterrole.yaml
@@ -317,3 +317,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update


### PR DESCRIPTION
The operator needs permissions to publish and monitor NPs in the custom namespace `openshift-manila-csi-driver`. See https://github.com/openshift/csi-operator/pull/424 for details.