### PR TITLE
OCPBUGS-61112: add Azure Disk CSI driver SA name to CredentialsRequest

### DIFF
--- a/manifests/03_credentials_request_azure.yaml
+++ b/manifests/03_credentials_request_azure.yaml
@@ -11,6 +11,7 @@ spec:
   serviceAccountNames:
   - azure-disk-csi-driver-operator
   - azure-disk-csi-driver-controller-sa
+  - azure-disk-csi-driver-node-sa
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec


### PR DESCRIPTION
This is a fixup of a change introduced in this PR: https://github.com/openshift/cluster-storage-operator/pull/364#discussion_r1234179872

The CSI Node service account should have been added at the time too, this is also recommended by upstream docs: https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/a9ce7ef234164b8b0799d985c52c841c8892bcb6/docs/workload-identity.md?plain=1#L32

cc @openshift/storage 