### PR TITLE
OCPBUGS-60637: remove static value for runAsUser in securityContext

### DIFF
--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/deployment.patch.yaml
@@ -64,6 +64,3 @@ spec:
         - name: guest-kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
-      securityContext:
-        # Hypershift on AKS does not support SCC and needs a specific user ID
-        runAsUser: 1001

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -107,7 +107,6 @@ spec:
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: azure-disk-csi-driver-operator

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/deployment.patch.yaml
@@ -65,6 +65,3 @@ spec:
         - name: guest-kubeconfig
           secret:
             secretName: service-network-admin-kubeconfig
-      securityContext:
-        # Hypershift on AKS does not support SCC and needs a specific user ID
-        runAsUser: 1001

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -107,7 +107,6 @@ spec:
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: azure-file-csi-driver-operator


### PR DESCRIPTION
See details in commit message. The following PRs have to be merged first:

- https://github.com/openshift/cluster-storage-operator/pull/616
- https://github.com/openshift/csi-operator/pull/431
- https://github.com/openshift/hypershift/pull/6786

hypershift-e2e-aks should be failing until the above PRs are merged. After they're merged the UID allocation will be more dynamic:

- AKS (ARO HCP) does not have SCC and HyperShift will allocate UID that operands have to reflect in  securityContext.runAsUser 
- in self-managed Azure (or any other OpenShift deployment) that has SCC the operands must **not** set securityContext.runAsUser as it is handled by SCC


/cc @openshift/storage @dobsonj @bryan-cox @enxebre 