### PR TITLE
OCPBUGS-61175: Add RBAC rule to let manila-csi-driver-operator manage NetworkPolicy in mgmt namespace

### DIFF
--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_manila-csi-driver-operator-role.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_manila-csi-driver-operator-role.yaml
@@ -85,3 +85,15 @@ rules:
   - replicasets
   verbs:
   - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/hypershift_role.patch.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/hypershift_role.patch.yaml
@@ -63,3 +63,18 @@
       - replicasets
     verbs:
       - get
+- op: "add"
+  path: "/rules/-"
+  value:
+    apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+      - get
+      - create
+      - delete
+      - patch
+      - update


### PR DESCRIPTION
The operator needs permissions to publish and monitor NPs in the custom namespace `openshift-manila-csi-driver`. Previous PR (https://github.com/openshift/cluster-storage-operator/pull/615) missed mgmt case.