### PR TITLE
OCPBUGS-62172: Add app label to Manila deployment

### DIFF
--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/deployment.patch.yaml
@@ -6,6 +6,7 @@ spec:
   template:
     metadata:
       labels:
+        app: manila-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         openshift.storage.network-policy.all-egress: allow
         openshift.storage.network-policy.api-server: allow

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -18,6 +18,7 @@ spec:
         openshift.io/required-scc: restricted-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
+        app: manila-csi-driver-operator
         hypershift.openshift.io/need-management-kas-access: "true"
         name: manila-csi-driver-operator
         openshift.storage.network-policy.all-egress: allow


### PR DESCRIPTION
So [HCP's e2e tests][1] can pick it up.

[1]: https://github.com/openshift/hypershift/blob/2d2fdfa36d919785567604fff9569d108c06b15c/test/e2e/util/util.go#L1640
