### PR TITLE
STOR-2560: Add readOnlyRootFilesystem to hypershift and ibm-cloud-managed

### DIFF
--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -128,7 +128,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -116,7 +116,7 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert

--- a/profile-patches/hypershift/10_deployment.yaml-patch
+++ b/profile-patches/hypershift/10_deployment.yaml-patch
@@ -87,12 +87,6 @@
     openshift.io/required-scc: restricted-v2
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 
-# Remove changes for readOnlyRootFilesystem
-- op: replace
-  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
-  value:
-    false
-
 # Hypershift allows the API server port to be defined in
 # hostedcluster.spec.networking.apiServer.port so in this case we add the
 # all-egress network policy to allow reaching the server on any port.

--- a/profile-patches/ibm-cloud-managed/10_deployment.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/10_deployment.yaml-patch
@@ -7,12 +7,6 @@
 - op: remove
   path: /spec/template/spec/nodeSelector
 
-# Remove changes for readOnlyRootFilesystem
-- op: replace
-  path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
-  value:
-    false
-
 # Hypershift allows the API server port to be defined in
 # hostedcluster.spec.networking.apiServer.port so in this case we add the
 # all-egress network policy to allow reaching the server on any port.


### PR DESCRIPTION
`readOnlyRootFilesystem` should be enabled in all versions of OpenShift