### PR TITLE
NO-JIRA: Update OCP documentation links to latest versions

### DIFF
--- a/assets/csidriveroperators/README.md
+++ b/assets/csidriveroperators/README.md
@@ -36,4 +36,4 @@ combined to generate the resulting assets, which are dumped to the `generated`
 subdirectory in the `standalone`, `hypershift/guest` and `hypershift/mgmt`
 directories.
 
-[hcp]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/hosted_control_planes/index
+[hcp]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/hosted_control_planes/index


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18