### PR TITLE
CNTRLPLANE-1544: manifests: Use restricted-v3 scc for the operator

### DIFF
--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -133,6 +133,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: nonroot-v2
+        openshift.io/required-scc: restricted-v3
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: cluster-storage-operator
@@ -121,10 +121,11 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: cluster-storage-operator-serving-cert
+      hostUsers: false
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
-        runAsUser: 11411
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: cluster-storage-operator

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: nonroot-v2
+        openshift.io/required-scc: restricted-v3
       labels:
         name: cluster-storage-operator
         openshift.storage.network-policy.dns: allow
@@ -37,14 +37,15 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 120 # Evict pods within 2 mins.
+      hostUsers: false
       priorityClassName: system-cluster-critical
       serviceAccountName: cluster-storage-operator
       securityContext:
+        # TODO: remove cluster-admin from the operator
         runAsNonRoot: true
-        # Force a specific UID, just in case this Pod matches a custom SCC with "runAsUser: type: runAsNonRoot".
-        # The UID value was chosen by a fair `echo $RANDOM` call.
-        # TODO: remove cluster-admin from the operator, then a specific UID won't be needed.
-        runAsUser: 11411
+        # runAsUser must be set, otherwise make update fails.
+        # This is the default value set by restricted-v3 scc.
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
This effectively enforces user namespaces.

I didn't really want to update the Hypershift manifest, but it cannot be skipped.