### PR TITLE
STOR-2766: Allow aws ebs driver to copy volumes

### DIFF
--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -30,6 +30,7 @@ spec:
       - ec2:CreateSnapshot
       - ec2:CreateTags
       - ec2:CreateVolume
+      - ec2:CopyVolumes
       - ec2:DeleteSnapshot
       - ec2:DeleteTags
       - ec2:DeleteVolume
@@ -38,6 +39,7 @@ spec:
       - ec2:DescribeTags
       - ec2:DescribeVolumes
       - ec2:DescribeVolumesModifications
+      - ec2:DescribeVolumeStatus
       - ec2:DetachVolume
       - ec2:ModifyVolume
       - ec2:DescribeAvailabilityZones


### PR DESCRIPTION
Based on https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/2716 
this is coming to OCP 4.22 in https://github.com/openshift/aws-ebs-csi-driver/pull/301