### PR TITLE
OCPBUGS-78291: Allow azure-disk operator to read VolumeAttributeClasses

### DIFF
--- a/assets/csidriveroperators/azure-disk/base/06_clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/base/06_clusterrole.yaml
@@ -215,6 +215,14 @@ rules:
   - update
   - delete
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+   - get
+   - list
+   - watch
+- apiGroups:
   - '*'
   resources:
   - events

--- a/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -212,6 +212,14 @@ rules:
   - update
   - delete
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - '*'
   resources:
   - events

--- a/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_clusterrole_azure-disk-csi-driver-operator-clusterrole.yaml
@@ -212,6 +212,14 @@ rules:
   - update
   - delete
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattributesclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - '*'
   resources:
   - events


### PR DESCRIPTION
The driver supports volume modification and thus the operator need to be able to read VACs to grant these permissions to the driver sidecars.


cc @openshift/storage 