### PR TITLE
STOR-2954: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/04_configmap.yaml
+++ b/manifests/04_configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-cluster-storage-operator
+  name: cluster-storage-operator-config
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Storage
+    config.openshift.io/inject-tls: "true"
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/manifests/10_deployment-hypershift.yaml
+++ b/manifests/10_deployment-hypershift.yaml
@@ -24,6 +24,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
@@ -131,6 +133,10 @@ spec:
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        - mountPath: /var/run/secrets/serving-cert
+          name: cluster-storage-operator-serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: config
         - mountPath: /etc/guest-kubeconfig
           name: guest-kubeconfig
       securityContext:
@@ -139,6 +145,12 @@ spec:
           type: RuntimeDefault
       serviceAccountName: cluster-storage-operator
       volumes:
+      - name: cluster-storage-operator-serving-cert
+        secret:
+          secretName: cluster-storage-operator-serving-cert
+      - configMap:
+          name: cluster-storage-operator-config
+        name: config
       - name: guest-kubeconfig
         secret:
           secretName: service-network-admin-kubeconfig

--- a/manifests/10_deployment-ibm-cloud-managed.yaml
+++ b/manifests/10_deployment-ibm-cloud-managed.yaml
@@ -29,6 +29,8 @@ spec:
       - args:
         - start
         - -v=2
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         command:
@@ -121,6 +123,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/secrets/serving-cert
           name: cluster-storage-operator-serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: config
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -144,3 +148,6 @@ spec:
       - name: cluster-storage-operator-serving-cert
         secret:
           secretName: cluster-storage-operator-serving-cert
+      - configMap:
+          name: cluster-storage-operator-config
+        name: config

--- a/manifests/10_deployment.yaml
+++ b/manifests/10_deployment.yaml
@@ -54,6 +54,8 @@ spec:
           args:
           - start
           - -v=2
+          - --config=/var/run/configmaps/config/config.yaml
+          - --terminate-on-files=/var/run/configmaps/config/config.yaml
           - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
           - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
           ports:
@@ -143,7 +145,12 @@ spec:
           volumeMounts:
             - mountPath: /var/run/secrets/serving-cert
               name: cluster-storage-operator-serving-cert
+            - mountPath: /var/run/configmaps/config
+              name: config
       volumes:
         - name: cluster-storage-operator-serving-cert
           secret:
             secretName: cluster-storage-operator-serving-cert
+        - name: config
+          configMap:
+            name: cluster-storage-operator-config

--- a/profile-patches/hypershift/10_deployment.yaml-patch
+++ b/profile-patches/hypershift/10_deployment.yaml-patch
@@ -19,18 +19,19 @@
 - op: remove
   path: /spec/template/spec/priorityClassName
 
-# Add guest-kubeconfig volume
+# Add guest-kubeconfig volume (append to existing volumes)
 - op: add
-  path: /spec/template/spec/volumes
+  path: /spec/template/spec/volumes/-
   value:
-    - name: guest-kubeconfig
-      secret:
-        secretName: service-network-admin-kubeconfig
+    name: guest-kubeconfig
+    secret:
+      secretName: service-network-admin-kubeconfig
+# Add guest-kubeconfig volumeMount (append to existing volumeMounts)
 - op: add
-  path: /spec/template/spec/containers/0/volumeMounts
+  path: /spec/template/spec/containers/0/volumeMounts/-
   value:
-    - name: guest-kubeconfig
-      mountPath: /etc/guest-kubeconfig
+    name: guest-kubeconfig
+    mountPath: /etc/guest-kubeconfig
 
 - op: add
   path: /spec/template/spec/containers/0/env/33


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a dedicated operator ConfigMap and updated deployments to mount and consume it.
  * Enabled operator graceful shutdown tied to the presence of the mounted config file.
  * Updated HyperShift/managed deployment templates to append guest kubeconfig, add control‑plane/component image env vars, and pass a guest-kubeconfig argument.
  * Adjusted pod annotations, labels, security context and scheduling preferences to align with platform requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->