### PR TITLE
STOR-2954, CNTRLPLANE-3625: Inject TLS from CVO to operators, update hypershift TLS based on CVO

### DIFF
--- a/assets/csidriveroperators/aws-ebs/base/03_configmap.yaml
+++ b/assets/csidriveroperators/aws-ebs/base/03_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-ebs-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    storage.openshift.io/remove-from: guest
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/aws-ebs/base/09_deployment.yaml
+++ b/assets/csidriveroperators/aws-ebs/base/09_deployment.yaml
@@ -26,6 +26,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -65,11 +67,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       serviceAccountName: aws-ebs-csi-driver-operator
       securityContext:
         runAsNonRoot: true
@@ -83,3 +91,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: aws-ebs-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: aws-ebs-csi-driver-operator-config

--- a/assets/csidriveroperators/aws-ebs/base/kustomization.yaml
+++ b/assets/csidriveroperators/aws-ebs/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - 03_configmap.yaml
   - 01_service.yaml
   - 03_role.yaml
   - 02_sa.yaml

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -79,6 +79,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: HYPERSHIFT_IMAGE
@@ -114,6 +116,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: aws-ebs-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -134,6 +140,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
@@ -168,3 +176,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: aws-ebs-csi-driver-operator-serving-cert
+      - configMap:
+          name: aws-ebs-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/aws-ebs/hypershift/mgmt/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: aws-ebs-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/apps_v1_deployment_aws-ebs-csi-driver-operator.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -55,6 +57,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: aws-ebs-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -71,6 +77,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -93,3 +101,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: aws-ebs-csi-driver-operator-serving-cert
+      - configMap:
+          name: aws-ebs-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/aws-ebs/standalone/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/aws-ebs/standalone/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  annotations:
+    storage.openshift.io/remove-from: guest
+  name: aws-ebs-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/azure-disk/base/03_configmap.yaml
+++ b/assets/csidriveroperators/azure-disk/base/03_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-disk-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    storage.openshift.io/remove-from: guest
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/azure-disk/base/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-disk/base/08_deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -66,11 +68,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       serviceAccountName: azure-disk-csi-driver-operator
       securityContext:
         runAsNonRoot: true
@@ -84,3 +92,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-disk-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: azure-disk-csi-driver-operator-config

--- a/assets/csidriveroperators/azure-disk/base/kustomization.yaml
+++ b/assets/csidriveroperators/azure-disk/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - 03_configmap.yaml
   - 01_service.yaml
   - 03_sa.yaml
   - 04_role.yaml

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -57,6 +57,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: DRIVER_CONTROL_PLANE_IMAGE
@@ -92,6 +94,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: azure-disk-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -110,6 +116,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
@@ -138,3 +146,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-disk-csi-driver-operator-serving-cert
+      - configMap:
+          name: azure-disk-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/azure-disk/hypershift/mgmt/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: azure-disk-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/azure-disk/standalone/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/apps_v1_deployment_azure-disk-csi-driver-operator.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -55,6 +57,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: azure-disk-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -71,6 +77,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -93,3 +101,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-disk-csi-driver-operator-serving-cert
+      - configMap:
+          name: azure-disk-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/azure-disk/standalone/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/azure-disk/standalone/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  annotations:
+    storage.openshift.io/remove-from: guest
+  name: azure-disk-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/azure-file/base/03_configmap.yaml
+++ b/assets/csidriveroperators/azure-file/base/03_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-file-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    storage.openshift.io/remove-from: guest
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/azure-file/base/08_deployment.yaml
+++ b/assets/csidriveroperators/azure-file/base/08_deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -66,11 +68,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       serviceAccountName: azure-file-csi-driver-operator
       securityContext:
         runAsNonRoot: true
@@ -84,3 +92,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-file-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: azure-file-csi-driver-operator-config

--- a/assets/csidriveroperators/azure-file/base/kustomization.yaml
+++ b/assets/csidriveroperators/azure-file/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - 03_configmap.yaml
   - 01_service.yaml
   - 03_sa.yaml
   - 04_role.yaml

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -57,6 +57,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: DRIVER_CONTROL_PLANE_IMAGE
@@ -92,6 +94,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: azure-file-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -110,6 +116,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
@@ -138,3 +146,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-file-csi-driver-operator-serving-cert
+      - configMap:
+          name: azure-file-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/azure-file/hypershift/mgmt/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: azure-file-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/azure-file/standalone/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/apps_v1_deployment_azure-file-csi-driver-operator.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -55,6 +57,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: azure-file-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -71,6 +77,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -93,3 +101,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: azure-file-csi-driver-operator-serving-cert
+      - configMap:
+          name: azure-file-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/azure-file/standalone/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/azure-file/standalone/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  annotations:
+    storage.openshift.io/remove-from: guest
+  name: azure-file-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/gcp-pd/03_configmap.yaml
+++ b/assets/csidriveroperators/gcp-pd/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gcp-pd-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/gcp-pd/07_deployment.yaml
+++ b/assets/csidriveroperators/gcp-pd/07_deployment.yaml
@@ -26,6 +26,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -63,11 +65,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: system-cluster-critical
       serviceAccountName: gcp-pd-csi-driver-operator
       nodeSelector:
@@ -90,3 +98,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: gcp-pd-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: gcp-pd-csi-driver-operator-config

--- a/assets/csidriveroperators/ibm-vpc-block/03_configmap.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibm-vpc-block-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
+++ b/assets/csidriveroperators/ibm-vpc-block/08_deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -62,11 +64,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: system-cluster-critical
       serviceAccountName: ibm-vpc-block-csi-driver-operator
       nodeSelector:
@@ -89,3 +97,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: ibm-vpc-block-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: ibm-vpc-block-csi-driver-operator-config

--- a/assets/csidriveroperators/openstack-cinder/base/03_configmap.yaml
+++ b/assets/csidriveroperators/openstack-cinder/base/03_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openstack-cinder-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    storage.openshift.io/remove-from: guest
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/openstack-cinder/base/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-cinder/base/07_deployment.yaml
@@ -24,6 +24,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -62,6 +64,8 @@ spec:
           mountPath: /tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
         name: openstack-cinder-csi-driver-operator
         resources:
           requests:
@@ -74,6 +78,10 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
       priorityClassName: system-cluster-critical
       serviceAccountName: openstack-cinder-csi-driver-operator
       volumes:
@@ -98,6 +106,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: openstack-cinder-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: openstack-cinder-csi-driver-operator-config
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/assets/csidriveroperators/openstack-cinder/base/kustomization.yaml
+++ b/assets/csidriveroperators/openstack-cinder/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - 03_configmap.yaml
   - 01_service.yaml
   - 02_sa.yaml
   - 03_role.yaml

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: openstack-cinder-csi-driver-operator
     release.openshift.io/desired-version: ${RELEASE_VERSION}
-    storage.openshift.io/remove-from: guest
   labels:
     hypershift.openshift.io/managed-by: cluster-storage-operator
   name: openstack-cinder-csi-driver-operator
@@ -58,6 +57,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: DRIVER_CONTROL_PLANE_IMAGE
@@ -87,6 +88,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: openstack-cinder-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -111,6 +116,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
@@ -160,3 +167,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: openstack-cinder-csi-driver-operator-serving-cert
+      - configMap:
+          name: openstack-cinder-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: openstack-cinder-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/v1_service_openstack-cinder-csi-driver-operator-metrics.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/generated/v1_service_openstack-cinder-csi-driver-operator-metrics.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: openstack-cinder-csi-driver-operator-serving-cert
-    storage.openshift.io/remove-from: guest
   labels:
     app: openstack-cinder-csi-driver-operator
   name: openstack-cinder-csi-driver-operator-metrics

--- a/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/kustomization.yaml
+++ b/assets/csidriveroperators/openstack-cinder/hypershift/mgmt/kustomization.yaml
@@ -27,3 +27,8 @@ patches:
       kind: Kustomization
       metadata:
         name: PLACEHOLDER
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=guest"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-cinder/standalone/generated/apps_v1_deployment_openstack-cinder-csi-driver-operator.yaml
@@ -28,6 +28,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -52,6 +54,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: openstack-cinder-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -74,6 +80,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -117,3 +125,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: openstack-cinder-csi-driver-operator-serving-cert
+      - configMap:
+          name: openstack-cinder-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/openstack-cinder/standalone/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/openstack-cinder/standalone/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  annotations:
+    storage.openshift.io/remove-from: guest
+  name: openstack-cinder-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/openstack-manila/base/03_configmap.yaml
+++ b/assets/csidriveroperators/openstack-manila/base/03_configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manila-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    storage.openshift.io/remove-from: guest
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/openstack-manila/base/07_deployment.yaml
+++ b/assets/csidriveroperators/openstack-manila/base/07_deployment.yaml
@@ -24,6 +24,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -65,6 +67,8 @@ spec:
           mountPath: /tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
         resources:
           requests:
             memory: 50Mi
@@ -76,6 +80,10 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
       priorityClassName: system-cluster-critical
       serviceAccountName: manila-csi-driver-operator
       volumes:
@@ -100,6 +108,9 @@ spec:
         secret:
           defaultMode: 420
           secretName: manila-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: manila-csi-driver-operator-config
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/assets/csidriveroperators/openstack-manila/base/kustomization.yaml
+++ b/assets/csidriveroperators/openstack-manila/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - 03_configmap.yaml
   - 01_namespace.yaml
   - 02_sa.yaml
   - 03_role.yaml

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: manila-csi-driver-operator
     release.openshift.io/desired-version: ${RELEASE_VERSION}
-    storage.openshift.io/remove-from: guest
   labels:
     hypershift.openshift.io/managed-by: cluster-storage-operator
   name: manila-csi-driver-operator
@@ -58,6 +57,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
         env:
         - name: DRIVER_CONTROL_PLANE_IMAGE
@@ -89,6 +90,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: manila-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -113,6 +118,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: hypershift-control-plane
       securityContext:
         runAsNonRoot: true
@@ -162,3 +169,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: manila-csi-driver-operator-serving-cert
+      - configMap:
+          name: manila-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_manila-csi-driver-operator-role.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_manila-csi-driver-operator-role.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: guest
   name: manila-csi-driver-operator-role
   namespace: ${CONTROLPLANE_NAMESPACE}
 rules:

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_manila-csi-driver-operator-rolebinding.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_manila-csi-driver-operator-rolebinding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: guest
   name: manila-csi-driver-operator-rolebinding
   namespace: ${CONTROLPLANE_NAMESPACE}
 roleRef:

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_configmap_manila-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_configmap_manila-csi-driver-operator-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: manila-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_service_manila-csi-driver-operator-metrics.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_service_manila-csi-driver-operator-metrics.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: manila-csi-driver-operator-serving-cert
-    storage.openshift.io/remove-from: guest
   labels:
     app: manila-csi-driver-operator
   name: manila-csi-driver-operator-metrics

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_serviceaccount_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_serviceaccount_manila-csi-driver-operator.yaml
@@ -3,7 +3,5 @@ imagePullSecrets:
 - name: pull-secret
 kind: ServiceAccount
 metadata:
-  annotations:
-    storage.openshift.io/remove-from: guest
   name: manila-csi-driver-operator
   namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/openstack-manila/hypershift/mgmt/kustomization.yaml
+++ b/assets/csidriveroperators/openstack-manila/hypershift/mgmt/kustomization.yaml
@@ -27,3 +27,8 @@ patches:
       kind: Kustomization
       metadata:
         name: PLACEHOLDER
+  - target:
+      annotationSelector: "storage.openshift.io/remove-from=guest"
+    patch: |
+      - op: "remove"
+        path: "/metadata/annotations/storage.openshift.io~1remove-from"

--- a/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_apps_v1_deployment_manila-csi-driver-operator.yaml
+++ b/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_apps_v1_deployment_manila-csi-driver-operator.yaml
@@ -28,6 +28,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -54,6 +56,10 @@ spec:
         image: ${OPERATOR_IMAGE}
         imagePullPolicy: IfNotPresent
         name: manila-csi-driver-operator
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -76,6 +82,8 @@ spec:
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -119,3 +127,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: manila-csi-driver-operator-serving-cert
+      - configMap:
+          name: manila-csi-driver-operator-config
+        name: operator-config

--- a/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_v1_configmap_manila-csi-driver-operator-config.yaml
+++ b/assets/csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_v1_configmap_manila-csi-driver-operator-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  annotations:
+    storage.openshift.io/remove-from: guest
+  name: manila-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers

--- a/assets/csidriveroperators/powervs-block/hypershift/mgmt/03_configmap.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/mgmt/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+kind: ConfigMap
+metadata:
+  name: powervs-block-csi-driver-operator-config
+  namespace: ${CONTROLPLANE_NAMESPACE}

--- a/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/hypershift/mgmt/06_deployment.yaml
@@ -30,6 +30,8 @@ spec:
         - args:
             - start
             - -v=${LOG_LEVEL}
+            - --config=/var/run/configmaps/config/config.yaml
+            - --terminate-on-files=/var/run/configmaps/config/config.yaml
             - --guest-kubeconfig=/etc/guest-kubeconfig/kubeconfig
           env:
             - name: DRIVER_IMAGE
@@ -63,11 +65,17 @@ spec:
             requests:
               memory: 50Mi
               cpu: 10m
+          ports:
+          - containerPort: 8443
+            name: metrics
+            protocol: TCP
           volumeMounts:
           - mountPath: /etc/guest-kubeconfig
             name: guest-kubeconfig
           - mountPath: /var/run/secrets/serving-cert
             name: serving-cert
+          - mountPath: /var/run/configmaps/config
+            name: operator-config
           terminationMessagePolicy: FallbackToLogsOnError
       priorityClassName: hypershift-control-plane
       serviceAccountName: powervs-block-csi-driver-operator
@@ -85,3 +93,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: powervs-block-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: powervs-block-csi-driver-operator-config

--- a/assets/csidriveroperators/powervs-block/standalone/03_configmap.yaml
+++ b/assets/csidriveroperators/powervs-block/standalone/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: powervs-block-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/powervs-block/standalone/06_deployment.yaml
+++ b/assets/csidriveroperators/powervs-block/standalone/06_deployment.yaml
@@ -24,6 +24,8 @@ spec:
       - args:
         - start
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         env:
         - name: DRIVER_IMAGE
           value: ${DRIVER_IMAGE}
@@ -57,11 +59,17 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         volumeMounts:
         - mountPath: /tmp
           name: tmp
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
       priorityClassName: system-cluster-critical
       serviceAccountName: powervs-block-csi-driver-operator
       nodeSelector:
@@ -84,3 +92,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: powervs-block-csi-driver-operator-serving-cert
+      - name: operator-config
+        configMap:
+          name: powervs-block-csi-driver-operator-config

--- a/assets/csidriveroperators/vsphere/03_configmap.yaml
+++ b/assets/csidriveroperators/vsphere/03_configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmware-vsphere-csi-driver-operator-config
+  namespace: openshift-cluster-csi-drivers
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/assets/csidriveroperators/vsphere/08_deployment.yaml
+++ b/assets/csidriveroperators/vsphere/08_deployment.yaml
@@ -28,6 +28,8 @@ spec:
         - start
         - --listen=0.0.0.0:8445
         - -v=${LOG_LEVEL}
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
         - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         env:
@@ -70,6 +72,8 @@ spec:
           mountPath: /etc/pki/ca-trust/extracted/pem
         - mountPath: /var/run/secrets/serving-cert
           name: vmware-vsphere-csi-driver-operator-metrics-serving-cert
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
         terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           readOnlyRootFilesystem: true
@@ -97,6 +101,9 @@ spec:
       - name: vmware-vsphere-csi-driver-operator-metrics-serving-cert
         secret:
           secretName: vmware-vsphere-csi-driver-operator-metrics-serving-cert
+      - name: operator-config
+        configMap:
+          name: vmware-vsphere-csi-driver-operator-config
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/pkg/operator/csidriveroperator/csioperatorclient/aws.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/aws.go
@@ -53,6 +53,7 @@ func GetAWSEBSCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 			"csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_aws-ebs-csi-driver-operator-clusterrole.yaml",
 			"csidriveroperators/aws-ebs/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_aws-ebs-csi-driver-operator-clusterrolebinding.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/aws-ebs/hypershift/mgmt/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/aws-ebs/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_aws-ebs-csi-driver-operator-role.yaml",
 			"csidriveroperators/aws-ebs/hypershift/mgmt/generated/v1_serviceaccount_aws-ebs-csi-driver-operator.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/aws.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/aws.go
@@ -32,6 +32,7 @@ func GetAWSEBSCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 	}
 
 	if !isHypershift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/aws-ebs/standalone/generated/v1_configmap_aws-ebs-csi-driver-operator-config.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/aws-ebs/standalone/generated/v1_serviceaccount_aws-ebs-csi-driver-operator.yaml",
 			"csidriveroperators/aws-ebs/standalone/generated/rbac.authorization.k8s.io_v1_role_aws-ebs-csi-driver-operator-role.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
@@ -34,6 +34,7 @@ func GetAzureDiskCSIOperatorConfig(isHyperShift bool) CSIOperatorConfig {
 	}
 
 	if !isHyperShift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/azure-disk/standalone/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/azure-disk/standalone/generated/v1_serviceaccount_azure-disk-csi-driver-operator.yaml",
 			"csidriveroperators/azure-disk/standalone/generated/rbac.authorization.k8s.io_v1_role_azure-disk-csi-driver-operator-role.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-disk.go
@@ -53,6 +53,7 @@ func GetAzureDiskCSIOperatorConfig(isHyperShift bool) CSIOperatorConfig {
 			"csidriveroperators/azure-disk/hypershift/guest/generated/rbac.authorization.k8s.io_v1_rolebinding_azure-disk-csi-driver-operator-rolebinding.yaml",
 			"csidriveroperators/azure-disk/hypershift/guest/generated/v1_serviceaccount_azure-disk-csi-driver-operator.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/azure-disk/hypershift/mgmt/generated/v1_configmap_azure-disk-csi-driver-operator-config.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/azure-disk/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_azure-disk-csi-driver-operator-role.yaml",
 			"csidriveroperators/azure-disk/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_azure-disk-csi-driver-operator-rolebinding.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
@@ -65,6 +65,7 @@ func GetAzureFileCSIOperatorConfig(isHyperShift bool) CSIOperatorConfig {
 			"csidriveroperators/azure-file/hypershift/guest/generated/rbac.authorization.k8s.io_v1_rolebinding_azure-file-csi-driver-operator-rolebinding.yaml",
 			"csidriveroperators/azure-file/hypershift/guest/generated/v1_serviceaccount_azure-file-csi-driver-operator.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/azure-file/hypershift/mgmt/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/azure-file/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_azure-file-csi-driver-operator-role.yaml",
 			"csidriveroperators/azure-file/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_azure-file-csi-driver-operator-rolebinding.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/azure-file.go
@@ -46,6 +46,7 @@ func GetAzureFileCSIOperatorConfig(isHyperShift bool) CSIOperatorConfig {
 	}
 
 	if !isHyperShift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/azure-file/standalone/generated/v1_configmap_azure-file-csi-driver-operator-config.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/azure-file/standalone/generated/v1_serviceaccount_azure-file-csi-driver-operator.yaml",
 			"csidriveroperators/azure-file/standalone/generated/rbac.authorization.k8s.io_v1_role_azure-file-csi-driver-operator-role.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/cinder.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/cinder.go
@@ -31,6 +31,7 @@ func GetOpenStackCinderCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 	}
 
 	if !isHypershift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/openstack-cinder/standalone/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/openstack-cinder/standalone/generated/v1_serviceaccount_openstack-cinder-csi-driver-operator.yaml",
 			"csidriveroperators/openstack-cinder/standalone/generated/v1_service_openstack-cinder-csi-driver-operator-metrics.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/cinder.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/cinder.go
@@ -50,6 +50,7 @@ func GetOpenStackCinderCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 			"csidriveroperators/openstack-cinder/hypershift/guest/generated/rbac.authorization.k8s.io_v1_rolebinding_openstack-cinder-csi-driver-operator-rolebinding.yaml",
 			"csidriveroperators/openstack-cinder/hypershift/guest/generated/v1_serviceaccount_openstack-cinder-csi-driver-operator.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/openstack-cinder/hypershift/mgmt/generated/v1_configmap_openstack-cinder-csi-driver-operator-config.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/openstack-cinder/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_openstack-cinder-csi-driver-operator-role.yaml",
 			"csidriveroperators/openstack-cinder/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_openstack-cinder-csi-driver-operator-rolebinding.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/gcp-pd.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/gcp-pd.go
@@ -21,9 +21,10 @@ func GetGCPPDCSIOperatorConfig() CSIOperatorConfig {
 	}
 
 	return CSIOperatorConfig{
-		CSIDriverName:   GCPPDCSIDriverName,
-		ConditionPrefix: "GCPPD",
-		Platform:        configv1.GCPPlatformType,
+		CSIDriverName:                 GCPPDCSIDriverName,
+		ConditionPrefix:               "GCPPD",
+		Platform:                      configv1.GCPPlatformType,
+		StandaloneOperatorConfigAsset: "csidriveroperators/gcp-pd/03_configmap.yaml",
 		StaticAssets: []string{
 			"csidriveroperators/gcp-pd/01_service.yaml",
 			"csidriveroperators/gcp-pd/02_sa.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/ibm-vpc-block.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/ibm-vpc-block.go
@@ -35,10 +35,11 @@ func GetIBMVPCBlockCSIOperatorConfig() CSIOperatorConfig {
 	}
 
 	return CSIOperatorConfig{
-		CSIDriverName:   IBMVPCBlockCSIDriverName,
-		ConditionPrefix: "IBMVPCBlock",
-		Platform:        configv1.IBMCloudPlatformType,
-		StatusFilter:    isNotExternalTopologyMode,
+		CSIDriverName:                 IBMVPCBlockCSIDriverName,
+		ConditionPrefix:               "IBMVPCBlock",
+		Platform:                      configv1.IBMCloudPlatformType,
+		StatusFilter:                  isNotExternalTopologyMode,
+		StandaloneOperatorConfigAsset: "csidriveroperators/ibm-vpc-block/03_configmap.yaml",
 		StaticAssets: []string{
 			"csidriveroperators/ibm-vpc-block/01_service.yaml",
 			"csidriveroperators/ibm-vpc-block/03_sa.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/manila.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/manila.go
@@ -61,6 +61,7 @@ func GetOpenStackManilaOperatorConfig(isHypershift bool, clients *csoclients.Cli
 			"csidriveroperators/openstack-manila/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrole_manila-csi-driver-operator-clusterrole.yaml",
 			"csidriveroperators/openstack-manila/hypershift/guest/generated/rbac.authorization.k8s.io_v1_clusterrolebinding_manila-csi-driver-operator-clusterrolebinding.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/openstack-manila/hypershift/mgmt/generated/v1_configmap_manila-csi-driver-operator-config.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_rolebinding_manila-csi-driver-operator-rolebinding.yaml",
 			"csidriveroperators/openstack-manila/hypershift/mgmt/generated/rbac.authorization.k8s.io_v1_role_manila-csi-driver-operator-role.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/manila.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/manila.go
@@ -43,6 +43,7 @@ func GetOpenStackManilaOperatorConfig(isHypershift bool, clients *csoclients.Cli
 	}
 
 	if !isHypershift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_v1_configmap_manila-csi-driver-operator-config.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/openstack-manila/standalone/generated/v1_namespace_openshift-manila-csi-driver.yaml",
 			"csidriveroperators/openstack-manila/standalone/generated/openshift-cluster-csi-drivers_v1_serviceaccount_manila-csi-driver-operator.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/powervs-block.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/powervs-block.go
@@ -48,6 +48,7 @@ func GetPowerVSBlockCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 			"csidriveroperators/powervs-block/hypershift/guest/04_clusterrole.yaml",
 			"csidriveroperators/powervs-block/hypershift/guest/05_clusterrolebinding.yaml",
 		}
+		csiDriverConfig.MgmtOperatorConfigAsset = "csidriveroperators/powervs-block/hypershift/mgmt/03_configmap.yaml"
 		csiDriverConfig.MgmtStaticAssets = []string{
 			"csidriveroperators/powervs-block/hypershift/mgmt/01_operator_role.yaml",
 			"csidriveroperators/powervs-block/hypershift/mgmt/01_sa.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/powervs-block.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/powervs-block.go
@@ -29,6 +29,7 @@ func GetPowerVSBlockCSIOperatorConfig(isHypershift bool) CSIOperatorConfig {
 	}
 
 	if !isHypershift {
+		csiDriverConfig.StandaloneOperatorConfigAsset = "csidriveroperators/powervs-block/standalone/03_configmap.yaml"
 		csiDriverConfig.StaticAssets = []string{
 			"csidriveroperators/powervs-block/standalone/01_sa.yaml",
 			"csidriveroperators/powervs-block/standalone/02_role.yaml",

--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -45,6 +45,12 @@ type CSIOperatorConfig struct {
 	// of deploying it as a static asset.
 	StandaloneOperatorConfigAsset string
 
+	// MgmtOperatorConfigAsset is the asset path of the operator config ConfigMap
+	// deployed in the mgmt cluster in HyperShift. When set, the HyperShift deployment
+	// controller injects TLS settings (minTLSVersion, cipherSuites) from the
+	// HostedControlPlane into this ConfigMap instead of deploying it as a static asset.
+	MgmtOperatorConfigAsset string
+
 	// CRAsset is name of the bindata asset with ClusterCSIDriver of the
 	// operator. Its logLevel & operatorLoglevel will be set by CSO.
 	CRAsset string

--- a/pkg/operator/csidriveroperator/csioperatorclient/types.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/types.go
@@ -39,6 +39,12 @@ type CSIOperatorConfig struct {
 	// when starting the driver in hypershift clusters
 	MgmtStaticAssets []string
 
+	// StandaloneOperatorConfigAsset is the asset path of the operator config ConfigMap
+	// for standalone clusters. When set, the deployment controller injects TLS settings
+	// (minTLSVersion, cipherSuites) from APIServer/cluster into this ConfigMap instead
+	// of deploying it as a static asset.
+	StandaloneOperatorConfigAsset string
+
 	// CRAsset is name of the bindata asset with ClusterCSIDriver of the
 	// operator. Its logLevel & operatorLoglevel will be set by CSO.
 	CRAsset string

--- a/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
+++ b/pkg/operator/csidriveroperator/csioperatorclient/vsphere.go
@@ -22,9 +22,10 @@ func GetVMwareVSphereCSIOperatorConfig() CSIOperatorConfig {
 	}
 
 	return CSIOperatorConfig{
-		CSIDriverName:   VMwareVSphereDriverName,
-		ConditionPrefix: "VSphere",
-		Platform:        configv1.VSpherePlatformType,
+		CSIDriverName:                 VMwareVSphereDriverName,
+		ConditionPrefix:               "VSphere",
+		Platform:                      configv1.VSpherePlatformType,
+		StandaloneOperatorConfigAsset: "csidriveroperators/vsphere/03_configmap.yaml",
 		StaticAssets: []string{
 			"csidriveroperators/vsphere/02_configmap.yaml",
 			"csidriveroperators/vsphere/03_sa.yaml",

--- a/pkg/operator/csidriveroperator/deploymentcontroller.go
+++ b/pkg/operator/csidriveroperator/deploymentcontroller.go
@@ -8,17 +8,14 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	sigsyaml "sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
@@ -285,55 +282,19 @@ func (c *CSIDriverOperatorDeploymentController) reconcileOperatorConfigMap(ctx c
 
 	apiServer, err := c.apiServerLister.Get("cluster")
 	if err != nil {
-		klog.Warningf("Failed to get APIServer cluster, using Intermediate TLS profile: %v", err)
-		apiServer = &configv1.APIServer{}
+		return fmt.Errorf("failed to get APIServer cluster: %w", err)
 	}
-	minTLSVersion, cipherSuites := tlsSettingsFromAPIServer(apiServer)
+	minTLSVersion, cipherSuites := tlsSettingsFromProfile(apiServer.Spec.TLSSecurityProfile)
 
-	cfg := &operatorv1alpha1.GenericOperatorConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operator.openshift.io/v1alpha1",
-			Kind:       "GenericOperatorConfig",
-		},
-		ServingInfo: configv1.HTTPServingInfo{
-			ServingInfo: configv1.ServingInfo{
-				MinTLSVersion: minTLSVersion,
-				CipherSuites:  cipherSuites,
-			},
-		},
-	}
-
-	configYAML, err := sigsyaml.Marshal(cfg)
+	yaml, err := operatorConfigYAML(minTLSVersion, cipherSuites)
 	if err != nil {
-		return fmt.Errorf("failed to serialize GenericOperatorConfig: %w", err)
+		return err
 	}
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
-	cm.Data["config.yaml"] = string(configYAML)
+	cm.Data["config.yaml"] = yaml
 
 	_, _, err = resourceapply.ApplyConfigMap(ctx, c.commonClients.KubeClient.CoreV1(), c.eventRecorder, cm)
 	return err
-}
-
-// tlsSettingsFromAPIServer returns the minTLSVersion and IANA cipher suite names
-// from the cluster APIServer TLS security profile, defaulting to Intermediate.
-func tlsSettingsFromAPIServer(apiServer *configv1.APIServer) (string, []string) {
-	profile := apiServer.Spec.TLSSecurityProfile
-	if profile == nil || profile.Type == "" {
-		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-		return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
-	}
-	if profile.Type == configv1.TLSProfileCustomType {
-		if profile.Custom == nil {
-			spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-			return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
-		}
-		return string(profile.Custom.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profile.Custom.Ciphers)
-	}
-	spec, ok := configv1.TLSProfiles[profile.Type]
-	if !ok || spec == nil {
-		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
-	}
-	return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
 }

--- a/pkg/operator/csidriveroperator/deploymentcontroller.go
+++ b/pkg/operator/csidriveroperator/deploymentcontroller.go
@@ -8,19 +8,24 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	sigsyaml "sigs.k8s.io/yaml"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
+	"github.com/openshift/cluster-storage-operator/assets"
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
@@ -41,6 +46,7 @@ type CommonCSIDeploymentController struct {
 	targetVersion     string
 	eventRecorder     events.Recorder
 	infraLister       configv1listers.InfrastructureLister
+	apiServerLister   configv1listers.APIServerLister
 	resyncInterval    time.Duration
 	factory           *factory.Factory
 }
@@ -121,6 +127,7 @@ func initCommonDeploymentParams(
 		resyncInterval:    resyncInterval,
 		eventRecorder:     eventRecorder.WithComponentSuffix(csiOperatorConfig.ConditionPrefix),
 		infraLister:       client.ConfigInformers.Config().V1().Infrastructures().Lister(),
+		apiServerLister:   client.ConfigInformers.Config().V1().APIServers().Lister(),
 	}
 	return c
 }
@@ -155,7 +162,8 @@ func NewCSIDriverOperatorDeploymentController(
 	f := c.initController(func(f *factory.Factory) {
 		f.WithInformers(
 			c.commonClients.KubeInformers.InformersFor(csoclients.CSIOperatorNamespace).Apps().V1().Deployments().Informer(),
-			c.commonClients.ConfigInformers.Config().V1().Infrastructures().Informer())
+			c.commonClients.ConfigInformers.Config().V1().Infrastructures().Informer(),
+			c.commonClients.ConfigInformers.Config().V1().APIServers().Informer())
 	})
 	c.factory = f
 	return c
@@ -197,6 +205,12 @@ func (c *CSIDriverOperatorDeploymentController) Sync(ctx context.Context, syncCt
 	}
 	if infra.Status.ControlPlaneTopology == configv1.ExternalTopologyMode {
 		requiredCopy.Spec.Template.Spec.NodeSelector = map[string]string{}
+	}
+
+	if c.csiOperatorConfig.StandaloneOperatorConfigAsset != "" {
+		if err := c.reconcileOperatorConfigMap(ctx); err != nil {
+			return err
+		}
 	}
 
 	lastGeneration := resourcemerge.ExpectedDeploymentGeneration(requiredCopy, opStatus.Generations)
@@ -254,4 +268,72 @@ func hasFinishedProgressing(deployment *appsv1.Deployment) bool {
 		}
 	}
 	return false
+}
+
+// reconcileOperatorConfigMap reads the standalone ConfigMap asset for name/namespace, builds a
+// typed GenericOperatorConfig with TLS settings from APIServer/cluster, and applies it.
+func (c *CSIDriverOperatorDeploymentController) reconcileOperatorConfigMap(ctx context.Context) error {
+	assetBytes, err := assets.ReadFile(c.csiOperatorConfig.StandaloneOperatorConfigAsset)
+	if err != nil {
+		return fmt.Errorf("failed to read operator config asset: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := sigsyaml.Unmarshal(assetBytes, cm); err != nil {
+		return fmt.Errorf("failed to decode operator config ConfigMap: %w", err)
+	}
+
+	apiServer, err := c.apiServerLister.Get("cluster")
+	if err != nil {
+		klog.Warningf("Failed to get APIServer cluster, using Intermediate TLS profile: %v", err)
+		apiServer = &configv1.APIServer{}
+	}
+	minTLSVersion, cipherSuites := tlsSettingsFromAPIServer(apiServer)
+
+	cfg := &operatorv1alpha1.GenericOperatorConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operator.openshift.io/v1alpha1",
+			Kind:       "GenericOperatorConfig",
+		},
+		ServingInfo: configv1.HTTPServingInfo{
+			ServingInfo: configv1.ServingInfo{
+				MinTLSVersion: minTLSVersion,
+				CipherSuites:  cipherSuites,
+			},
+		},
+	}
+
+	configYAML, err := sigsyaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to serialize GenericOperatorConfig: %w", err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["config.yaml"] = string(configYAML)
+
+	_, _, err = resourceapply.ApplyConfigMap(ctx, c.commonClients.KubeClient.CoreV1(), c.eventRecorder, cm)
+	return err
+}
+
+// tlsSettingsFromAPIServer returns the minTLSVersion and IANA cipher suite names
+// from the cluster APIServer TLS security profile, defaulting to Intermediate.
+func tlsSettingsFromAPIServer(apiServer *configv1.APIServer) (string, []string) {
+	profile := apiServer.Spec.TLSSecurityProfile
+	if profile == nil || profile.Type == "" {
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	}
+	if profile.Type == configv1.TLSProfileCustomType {
+		if profile.Custom == nil {
+			spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+			return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+		}
+		return string(profile.Custom.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profile.Custom.Ciphers)
+	}
+	spec, ok := configv1.TLSProfiles[profile.Type]
+	if !ok || spec == nil {
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
 }

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -8,22 +8,28 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/cluster-storage-operator/assets"
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
 	csoutils "github.com/openshift/cluster-storage-operator/pkg/utils"
 	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 var _ factory.Controller = &HyperShiftDeploymentController{}
@@ -183,6 +189,12 @@ func (c *HyperShiftDeploymentController) Sync(ctx context.Context, syncCtx facto
 		return err
 	}
 
+	if c.csiOperatorConfig.MgmtOperatorConfigAsset != "" {
+		if err := c.reconcileOperatorConfigMap(ctx); err != nil {
+			return err
+		}
+	}
+
 	lastGeneration := resourcemerge.ExpectedDeploymentGeneration(requiredCopy, opStatus.Generations)
 	deployment, _, err := resourceapply.ApplyDeployment(ctx, c.mgmtClient.KubeClient.AppsV1(), c.eventRecorder, requiredCopy, lastGeneration)
 	if err != nil {
@@ -194,6 +206,84 @@ func (c *HyperShiftDeploymentController) Sync(ctx context.Context, syncCtx facto
 	}
 
 	return checkDeploymentHealth(ctx, c.mgmtClient.KubeClient.AppsV1(), deployment)
+}
+
+// reconcileOperatorConfigMap reads the mgmt ConfigMap asset for name/namespace, builds a
+// typed GenericOperatorConfig with TLS settings from the HostedControlPlane, and applies it.
+func (c *HyperShiftDeploymentController) reconcileOperatorConfigMap(ctx context.Context) error {
+	assetBytes, err := assets.ReadFile(c.csiOperatorConfig.MgmtOperatorConfigAsset)
+	if err != nil {
+		return fmt.Errorf("failed to read operator config asset: %w", err)
+	}
+
+	nsReplacer := strings.NewReplacer("${CONTROLPLANE_NAMESPACE}", c.controlNamespace)
+	assetContent := nsReplacer.Replace(string(assetBytes))
+
+	cm := &corev1.ConfigMap{}
+	if err := sigsyaml.Unmarshal([]byte(assetContent), cm); err != nil {
+		return fmt.Errorf("failed to decode operator config ConfigMap: %w", err)
+	}
+
+	minTLSVersion, cipherSuites, err := c.getHostedControlPlaneTLSSettings()
+	if err != nil {
+		return err
+	}
+
+	cfg := &operatorv1alpha1.GenericOperatorConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operator.openshift.io/v1alpha1",
+			Kind:       "GenericOperatorConfig",
+		},
+		ServingInfo: configv1.HTTPServingInfo{
+			ServingInfo: configv1.ServingInfo{
+				MinTLSVersion: minTLSVersion,
+				CipherSuites:  cipherSuites,
+			},
+		},
+	}
+
+	configYAML, err := sigsyaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to serialize GenericOperatorConfig: %w", err)
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["config.yaml"] = string(configYAML)
+
+	_, _, err = resourceapply.ApplyConfigMap(ctx, c.mgmtClient.KubeClient.CoreV1(), c.eventRecorder, cm)
+	return err
+}
+
+func (c *HyperShiftDeploymentController) getHostedControlPlaneTLSSettings() (string, []string, error) {
+	hcp, err := c.getHostedControlPlane()
+	if err != nil {
+		klog.Warningf("Failed to get HostedControlPlane, falling back to Intermediate TLS profile: %v", err)
+		hcp = &unstructured.Unstructured{}
+	}
+	return tlsSettingsFromHCP(hcp)
+}
+
+// tlsSettingsFromHCP reads the TLS security profile from an HCP unstructured object
+// and returns the minTLSVersion and IANA cipher suite names.
+func tlsSettingsFromHCP(hcp *unstructured.Unstructured) (string, []string, error) {
+	profileType, _, _ := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "type")
+
+	if configv1.TLSProfileType(profileType) == configv1.TLSProfileCustomType {
+		ciphers, _, _ := unstructured.NestedStringSlice(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "ciphers")
+		minVersion, _, _ := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "minTLSVersion")
+		return minVersion, crypto.OpenSSLToIANACipherSuites(ciphers), nil
+	}
+
+	pt := configv1.TLSProfileType(profileType)
+	if pt == "" {
+		pt = configv1.TLSProfileIntermediateType
+	}
+	profileSpec, ok := configv1.TLSProfiles[pt]
+	if !ok || profileSpec == nil {
+		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers), nil
 }
 
 func (c *HyperShiftDeploymentController) Run(ctx context.Context, workers int) {

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -9,21 +9,18 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	"github.com/openshift/cluster-storage-operator/assets"
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
 	csoutils "github.com/openshift/cluster-storage-operator/pkg/utils"
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/status"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -229,27 +226,14 @@ func (c *HyperShiftDeploymentController) reconcileOperatorConfigMap(ctx context.
 		return err
 	}
 
-	cfg := &operatorv1alpha1.GenericOperatorConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "operator.openshift.io/v1alpha1",
-			Kind:       "GenericOperatorConfig",
-		},
-		ServingInfo: configv1.HTTPServingInfo{
-			ServingInfo: configv1.ServingInfo{
-				MinTLSVersion: minTLSVersion,
-				CipherSuites:  cipherSuites,
-			},
-		},
-	}
-
-	configYAML, err := sigsyaml.Marshal(cfg)
+	yaml, err := operatorConfigYAML(minTLSVersion, cipherSuites)
 	if err != nil {
-		return fmt.Errorf("failed to serialize GenericOperatorConfig: %w", err)
+		return err
 	}
 	if cm.Data == nil {
 		cm.Data = make(map[string]string)
 	}
-	cm.Data["config.yaml"] = string(configYAML)
+	cm.Data["config.yaml"] = yaml
 
 	_, _, err = resourceapply.ApplyConfigMap(ctx, c.mgmtClient.KubeClient.CoreV1(), c.eventRecorder, cm)
 	return err
@@ -258,32 +242,41 @@ func (c *HyperShiftDeploymentController) reconcileOperatorConfigMap(ctx context.
 func (c *HyperShiftDeploymentController) getHostedControlPlaneTLSSettings() (string, []string, error) {
 	hcp, err := c.getHostedControlPlane()
 	if err != nil {
-		klog.Warningf("Failed to get HostedControlPlane, falling back to Intermediate TLS profile: %v", err)
-		hcp = &unstructured.Unstructured{}
+		return "", nil, fmt.Errorf("failed to get HostedControlPlane: %w", err)
 	}
 	return tlsSettingsFromHCP(hcp)
 }
 
-// tlsSettingsFromHCP reads the TLS security profile from an HCP unstructured object
+// tlsSettingsFromHCP extracts the TLS security profile from an HCP unstructured object
 // and returns the minTLSVersion and IANA cipher suite names.
 func tlsSettingsFromHCP(hcp *unstructured.Unstructured) (string, []string, error) {
-	profileType, _, _ := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "type")
-
-	if configv1.TLSProfileType(profileType) == configv1.TLSProfileCustomType {
-		ciphers, _, _ := unstructured.NestedStringSlice(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "ciphers")
-		minVersion, _, _ := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "minTLSVersion")
-		return minVersion, crypto.OpenSSLToIANACipherSuites(ciphers), nil
+	profileType, _, err := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "type")
+	if err != nil {
+		klog.Warningf("Failed to get HCP TLS profile type: %v", err)
 	}
 
-	pt := configv1.TLSProfileType(profileType)
-	if pt == "" {
-		pt = configv1.TLSProfileIntermediateType
+	profile := &configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileType(profileType),
 	}
-	profileSpec, ok := configv1.TLSProfiles[pt]
-	if !ok || profileSpec == nil {
-		profileSpec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	if profile.Type == configv1.TLSProfileCustomType {
+		ciphers, _, err := unstructured.NestedStringSlice(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "ciphers")
+		if err != nil {
+			klog.Warningf("Failed to get HCP custom TLS ciphers: %v", err)
+		}
+		minVersion, _, err := unstructured.NestedString(hcp.UnstructuredContent(), "spec", "configuration", "apiServer", "tlsSecurityProfile", "custom", "minTLSVersion")
+		if err != nil {
+			klog.Warningf("Failed to get HCP custom TLS minVersion: %v", err)
+		}
+		profile.Custom = &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.TLSProtocolVersion(minVersion),
+				Ciphers:       ciphers,
+			},
+		}
 	}
-	return string(profileSpec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profileSpec.Ciphers), nil
+
+	minTLSVersion, cipherSuites := tlsSettingsFromProfile(profile)
+	return minTLSVersion, cipherSuites, nil
 }
 
 func (c *HyperShiftDeploymentController) Run(ctx context.Context, workers int) {

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
@@ -1,0 +1,100 @@
+package csidriveroperator
+
+import (
+	"maps"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func tlsProfileHCP(profileType string, extras map[string]any) *unstructured.Unstructured {
+	spec := map[string]any{}
+	if profileType != "" {
+		tlsProfile := map[string]any{"type": profileType}
+		maps.Copy(tlsProfile, extras)
+		spec = map[string]any{
+			"configuration": map[string]any{
+				"apiServer": map[string]any{
+					"tlsSecurityProfile": tlsProfile,
+				},
+			},
+		}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{"spec": spec}}
+}
+
+func TestTLSSettingsFromHCP(t *testing.T) {
+	modernIANA := []string{
+		"TLS_AES_128_GCM_SHA256",
+		"TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256",
+	}
+	intermediateIANA := []string{
+		"TLS_AES_128_GCM_SHA256",
+		"TLS_AES_256_GCM_SHA384",
+		"TLS_CHACHA20_POLY1305_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+	}
+
+	tests := []struct {
+		name           string
+		hcp            *unstructured.Unstructured
+		wantMinVersion string
+		wantCiphers    []string
+	}{
+		{
+			name:           "empty profile defaults to Intermediate",
+			hcp:            tlsProfileHCP("", nil),
+			wantMinVersion: string(configv1.VersionTLS12),
+			wantCiphers:    intermediateIANA,
+		},
+		{
+			name:           "Intermediate profile",
+			hcp:            tlsProfileHCP(string(configv1.TLSProfileIntermediateType), nil),
+			wantMinVersion: string(configv1.VersionTLS12),
+			wantCiphers:    intermediateIANA,
+		},
+		{
+			name:           "Modern profile",
+			hcp:            tlsProfileHCP(string(configv1.TLSProfileModernType), nil),
+			wantMinVersion: string(configv1.VersionTLS13),
+			wantCiphers:    modernIANA,
+		},
+		{
+			name: "Custom profile",
+			hcp: tlsProfileHCP(string(configv1.TLSProfileCustomType), map[string]any{
+				"custom": map[string]any{
+					"minTLSVersion": "VersionTLS13",
+					"ciphers":       []any{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES256-GCM-SHA384"},
+				},
+			}),
+			wantMinVersion: "VersionTLS13",
+			wantCiphers: []string{
+				"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			},
+		},
+		{
+			name:           "unknown profile type falls back to Intermediate",
+			hcp:            tlsProfileHCP("SomeUnknownProfile", nil),
+			wantMinVersion: string(configv1.VersionTLS12),
+			wantCiphers:    intermediateIANA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVersion, gotCiphers, err := tlsSettingsFromHCP(tt.hcp)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantMinVersion, gotVersion)
+			assert.Equal(t, tt.wantCiphers, gotCiphers)
+		})
+	}
+}

--- a/pkg/operator/csidriveroperator/tls.go
+++ b/pkg/operator/csidriveroperator/tls.go
@@ -1,0 +1,49 @@
+package csidriveroperator
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"github.com/openshift/library-go/pkg/crypto"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// tlsSettingsFromProfile returns minTLSVersion and IANA cipher suite names from a TLS
+// security profile, defaulting to Intermediate if nil, empty, or unknown.
+func tlsSettingsFromProfile(profile *configv1.TLSSecurityProfile) (string, []string) {
+	if profile == nil || profile.Type == "" {
+		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+	}
+	if profile.Type == configv1.TLSProfileCustomType {
+		if profile.Custom == nil {
+			spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+			return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+		}
+		return string(profile.Custom.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(profile.Custom.Ciphers)
+	}
+	spec, ok := configv1.TLSProfiles[profile.Type]
+	if !ok || spec == nil {
+		spec = configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	}
+	return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
+}
+
+// operatorConfigYAML produces a minimal GenericOperatorConfig YAML with only
+// the TLS fields set, omitting all zero-value fields that the typed struct would emit.
+func operatorConfigYAML(minTLSVersion string, cipherSuites []string) (string, error) {
+	cfg := map[string]interface{}{
+		"apiVersion": operatorv1alpha1.SchemeGroupVersion.String(),
+		"kind":       "GenericOperatorConfig",
+		"servingInfo": map[string]interface{}{
+			"minTLSVersion": minTLSVersion,
+			"cipherSuites":  cipherSuites,
+		},
+	}
+	data, err := sigsyaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize GenericOperatorConfig: %w", err)
+	}
+	return string(data), nil
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added operator configuration management for CSI drivers (AWS EBS, Azure Disk, Azure File, GCP PD, IBM VPC Block, OpenStack Cinder, OpenStack Manila, PowerVS Block, vSphere).
  * Enabled TLS security profile management for HyperShift deployments.
  * Added support for dynamic operator configuration reloads.
  * Exposed metrics endpoints for CSI driver operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->