### PR TITLE
OCPBUGS-88299: Let gcp-pd csi driver operator to use SCC `hostnetwork-v2`

### DIFF
--- a/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
+++ b/assets/csidriveroperators/gcp-pd/05_clusterrole.yaml
@@ -7,6 +7,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - privileged
+  - hostnetwork-v2
   resources:
   - securitycontextconstraints
   verbs:


### PR DESCRIPTION
gcp-pd csi driver operator will create a ClusterRole to let controller deployments use `hostnetwork-v2`

https://redhat.atlassian.net/browse/OCPBUGS-88299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permissions for the GCP PD CSI driver operator to enable support for additional security configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->