### PR TITLE
NO-JIRA: Hypershift missing count storage classes metrics

### DIFF
--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -290,6 +290,7 @@ func (hsr *HyperShiftStarter) StartOperator(ctx context.Context) error {
 	}
 
 	metrics.InitializeVACMismatchMetrics(hsr.commonClients)
+	metrics.CountStorageClasses(hsr.commonClients)
 
 	csiDriverController, _ := csidriveroperator.NewHypershiftDriverStarter(
 		hsr.commonClients,


### PR DESCRIPTION
I found out that operators in Hypershift don't count storage classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added storage-class metric collection during operator startup, improving monitoring and visibility into cluster storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->