### PR TITLE
STOR-2918: update AWS EBS CSI credentials request policy to mirror upstream

### DIFF
--- a/manifests/03_credentials_request_aws.yaml
+++ b/manifests/03_credentials_request_aws.yaml
@@ -42,6 +42,10 @@ spec:
       - ec2:ModifyVolume
       - ec2:DescribeAvailabilityZones
       - ec2:EnableFastSnapshotRestores
+      - ec2:DescribeInstanceTypes
+      - ec2:DescribeVolumeStatus
+      - ec2:CopyVolumes
+      - ec2:LockSnapshot
       resource: "*"
     - effect: Allow
       action:


### PR DESCRIPTION
Update AWS EBS credentials policy. We wanted this to be more aligned with upstream changes, but due to technical differences between upstream and OpenShift, we can't have a policy larger than 2048 bytes. Hence, we have to keep it as it is for now.

## Coordination checklist

This CredentialsRequest change must be reflected in the following places before merging:

- [ ] ROSA HCP managed policy — follow the update process: https://source.redhat.com/departments/products_and_global_engineering/sre/wiki/aws_managed_policy_requirements_process_for_rosa_hcp
- [ ] HyperShift IAM role — https://github.com/openshift/hypershift/blob/5e182bedfbda84fc65f5b6d41640d55b2ed1d33b/cmd/infra/aws/iam.go#L96
- [ ] STS / manual-mode IAM policies (if applicable)
- [ ] Release notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Updates**
  * Updated AWS permissions to support additional EC2 instance type, volume, and snapshot operations for the EBS CSI driver.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->