### PR TITLE
 STOR-3056: inject TLS adherence from API to vsphere problem detector configmap

### DIFF
--- a/assets/vsphere_problem_detector/07_deployment.yaml
+++ b/assets/vsphere_problem_detector/07_deployment.yaml
@@ -27,6 +27,8 @@ spec:
       - args:
         - start
         - --listen=0.0.0.0:8444
+        - --config=/var/run/configmaps/config/config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/config.yaml
         - --v=${LOG_LEVEL}
         env:
         - name: POD_NAME
@@ -49,6 +51,8 @@ spec:
         - name: trusted-ca-bundle
           mountPath: /etc/pki/ca-trust/extracted/pem
           readOnly: true
+        - mountPath: /var/run/configmaps/config
+          name: operator-config
         terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           readOnlyRootFilesystem: true
@@ -77,6 +81,9 @@ spec:
           items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
+      - name: operator-config
+        configMap:
+          name: vsphere-problem-detector-operator-config
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/assets/vsphere_problem_detector/08_operator_config.yaml
+++ b/assets/vsphere_problem_detector/08_operator_config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vsphere-problem-detector-operator-config
+  namespace: openshift-cluster-storage-operator
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/pkg/operator/csidriveroperator/deploymentcontroller.go
+++ b/pkg/operator/csidriveroperator/deploymentcontroller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
+	csotls "github.com/openshift/cluster-storage-operator/pkg/operator/tls"
 	csoutils "github.com/openshift/cluster-storage-operator/pkg/utils"
 )
 
@@ -284,9 +285,9 @@ func (c *CSIDriverOperatorDeploymentController) reconcileOperatorConfigMap(ctx c
 	if err != nil {
 		return fmt.Errorf("failed to get APIServer cluster: %w", err)
 	}
-	minTLSVersion, cipherSuites := tlsSettingsFromProfile(apiServer.Spec.TLSSecurityProfile)
+	minTLSVersion, cipherSuites := csotls.TLSSettingsFromProfile(apiServer.Spec.TLSSecurityProfile)
 
-	yaml, err := operatorConfigYAML(minTLSVersion, cipherSuites)
+	yaml, err := csotls.OperatorConfigYAML(minTLSVersion, cipherSuites)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/csidriveroperator/csioperatorclient"
+	csotls "github.com/openshift/cluster-storage-operator/pkg/operator/tls"
 	csoutils "github.com/openshift/cluster-storage-operator/pkg/utils"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -226,7 +227,7 @@ func (c *HyperShiftDeploymentController) reconcileOperatorConfigMap(ctx context.
 		return err
 	}
 
-	yaml, err := operatorConfigYAML(minTLSVersion, cipherSuites)
+	yaml, err := csotls.OperatorConfigYAML(minTLSVersion, cipherSuites)
 	if err != nil {
 		return err
 	}
@@ -275,7 +276,7 @@ func tlsSettingsFromHCP(hcp *unstructured.Unstructured) (string, []string, error
 		}
 	}
 
-	minTLSVersion, cipherSuites := tlsSettingsFromProfile(profile)
+	minTLSVersion, cipherSuites := csotls.TLSSettingsFromProfile(profile)
 	return minTLSVersion, cipherSuites, nil
 }
 

--- a/pkg/operator/tls/tls.go
+++ b/pkg/operator/tls/tls.go
@@ -1,4 +1,4 @@
-package csidriveroperator
+package tls
 
 import (
 	"fmt"
@@ -9,9 +9,9 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
-// tlsSettingsFromProfile returns minTLSVersion and IANA cipher suite names from a TLS
+// TLSSettingsFromProfile returns minTLSVersion and IANA cipher suite names from a TLS
 // security profile, defaulting to Intermediate if nil, empty, or unknown.
-func tlsSettingsFromProfile(profile *configv1.TLSSecurityProfile) (string, []string) {
+func TLSSettingsFromProfile(profile *configv1.TLSSecurityProfile) (string, []string) {
 	if profile == nil || profile.Type == "" {
 		spec := configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
 		return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
@@ -30,9 +30,9 @@ func tlsSettingsFromProfile(profile *configv1.TLSSecurityProfile) (string, []str
 	return string(spec.MinTLSVersion), crypto.OpenSSLToIANACipherSuites(spec.Ciphers)
 }
 
-// operatorConfigYAML produces a minimal GenericOperatorConfig YAML with only
+// OperatorConfigYAML produces a minimal GenericOperatorConfig YAML with only
 // the TLS fields set, omitting all zero-value fields that the typed struct would emit.
-func operatorConfigYAML(minTLSVersion string, cipherSuites []string) (string, error) {
+func OperatorConfigYAML(minTLSVersion string, cipherSuites []string) (string, error) {
 	cfg := map[string]interface{}{
 		"apiVersion": operatorv1alpha1.SchemeGroupVersion.String(),
 		"kind":       "GenericOperatorConfig",

--- a/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
+++ b/pkg/operator/vsphereproblemdetector/vsphere_problem_detector_starter.go
@@ -15,9 +15,11 @@ import (
 	"github.com/openshift/cluster-storage-operator/assets"
 	"github.com/openshift/cluster-storage-operator/pkg/csoclients"
 	"github.com/openshift/cluster-storage-operator/pkg/operator/configobservation/util"
+	csotls "github.com/openshift/cluster-storage-operator/pkg/operator/tls"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/controller/manager"
 	"github.com/openshift/library-go/pkg/operator/csi/csidrivercontrollerservicecontroller"
+
 	"github.com/openshift/library-go/pkg/operator/deploymentcontroller"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
@@ -27,9 +29,12 @@ import (
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 const (
@@ -38,16 +43,19 @@ const (
 	cloudCredSecretName                 = "vsphere-cloud-credentials"
 	metricsCertSecretName               = "vsphere-problem-detector-serving-cert"
 	cloudConfigNamespace                = "openshift-config"
+	operatorConfigAsset                 = "vsphere_problem_detector/08_operator_config.yaml"
 )
 
 type VSphereProblemDetectorStarter struct {
-	controller     manager.ControllerManager
-	operatorClient v1helpers.OperatorClientWithFinalizers
-	infraLister    openshiftv1.InfrastructureLister
-	versionGetter  status.VersionGetter
-	targetVersion  string
-	eventRecorder  events.Recorder
-	running        bool
+	controller      manager.ControllerManager
+	operatorClient  v1helpers.OperatorClientWithFinalizers
+	infraLister     openshiftv1.InfrastructureLister
+	apiServerLister openshiftv1.APIServerLister
+	kubeClient      kubernetes.Interface
+	versionGetter   status.VersionGetter
+	targetVersion   string
+	eventRecorder   events.Recorder
+	running         bool
 }
 
 func NewVSphereProblemDetectorStarter(
@@ -57,16 +65,19 @@ func NewVSphereProblemDetectorStarter(
 	targetVersion string,
 	eventRecorder events.Recorder) factory.Controller {
 	c := &VSphereProblemDetectorStarter{
-		operatorClient: clients.OperatorClient,
-		infraLister:    clients.ConfigInformers.Config().V1().Infrastructures().Lister(),
-		versionGetter:  versionGetter,
-		targetVersion:  targetVersion,
-		eventRecorder:  eventRecorder.WithComponentSuffix("VSphereProblemDetectorStarter"),
+		operatorClient:  clients.OperatorClient,
+		infraLister:     clients.ConfigInformers.Config().V1().Infrastructures().Lister(),
+		apiServerLister: clients.ConfigInformers.Config().V1().APIServers().Lister(),
+		kubeClient:      clients.KubeClient,
+		versionGetter:   versionGetter,
+		targetVersion:   targetVersion,
+		eventRecorder:   eventRecorder.WithComponentSuffix("VSphereProblemDetectorStarter"),
 	}
 	c.controller = c.createVSphereProblemDetectorManager(clients, resyncInterval)
 	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(clients.OperatorClient).WithInformers(
 		clients.OperatorClient.Informer(),
 		clients.ConfigInformers.Config().V1().Infrastructures().Informer(),
+		clients.ConfigInformers.Config().V1().APIServers().Informer(),
 	).ToController("VSphereProblemDetectorStarter", eventRecorder)
 }
 
@@ -99,6 +110,10 @@ func (c *VSphereProblemDetectorStarter) sync(ctx context.Context, syncCtx factor
 	// if not vsphere turn without any error
 	if platform != configv1.VSpherePlatformType {
 		return nil
+	}
+
+	if err := c.reconcileOperatorConfigMap(ctx); err != nil {
+		return err
 	}
 
 	if !c.running {
@@ -225,6 +240,36 @@ func (c *VSphereProblemDetectorStarter) WithConfigMapHashAnnotationHook(namespac
 		// Add the hash to Deployment annotations
 		return addObjectHash(deployment, inputHashes)
 	}
+}
+
+func (c *VSphereProblemDetectorStarter) reconcileOperatorConfigMap(ctx context.Context) error {
+	assetBytes, err := assets.ReadFile(operatorConfigAsset)
+	if err != nil {
+		return fmt.Errorf("failed to read operator config asset: %w", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := sigsyaml.Unmarshal(assetBytes, cm); err != nil {
+		return fmt.Errorf("failed to decode operator config ConfigMap: %w", err)
+	}
+
+	apiServer, err := c.apiServerLister.Get("cluster")
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer cluster: %w", err)
+	}
+	minTLSVersion, cipherSuites := csotls.TLSSettingsFromProfile(apiServer.Spec.TLSSecurityProfile)
+
+	yaml, err := csotls.OperatorConfigYAML(minTLSVersion, cipherSuites)
+	if err != nil {
+		return err
+	}
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data["config.yaml"] = yaml
+
+	_, _, err = resourceapply.ApplyConfigMap(ctx, c.kubeClient.CoreV1(), c.eventRecorder, cm)
+	return err
 }
 
 func addObjectHash(deployment *appsv1.Deployment, inputHashes map[string]string) error {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2954

1. Inject TLS configuration from the API into the vsphere-problem-detector ConfigMap.
2. Refactor TLS utilities into a shared package for reuse across other components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ConfigMap-backed operator configuration for the vSphere Problem Detector, with TLS settings derived from the cluster’s TLS security profile.
  * Updated the operator deployment to read its config from the mounted ConfigMap and support configuration/termination behavior via new CLI arguments.
* **Bug Fixes**
  * Improved TLS configuration consistency across operator components and hosted control planes.
  * Ensures the required operator ConfigMap is reconciled before controllers start, failing early if it can’t be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->