### PR TITLE
OCPBUGS-99492: NetworkPolicies should use numeric ports instead of named ports

### DIFF
--- a/manifests/09_network-policy-allow-to-dns.yaml
+++ b/manifests/09_network-policy-allow-to-dns.yaml
@@ -23,8 +23,8 @@ spec:
           dns.operator.openshift.io/daemonset-dns: default
     ports:
     - protocol: TCP
-      port: dns-tcp
+      port: 5353
     - protocol: UDP
-      port: dns
+      port: 5353
   policyTypes:
   - Egress

--- a/manifests/09_network-policy-cso-allow-to-dns.yaml
+++ b/manifests/09_network-policy-cso-allow-to-dns.yaml
@@ -23,8 +23,8 @@ spec:
           dns.operator.openshift.io/daemonset-dns: default
     ports:
     - protocol: TCP
-      port: dns-tcp
+      port: 5353
     - protocol: UDP
-      port: dns
+      port: 5353
   policyTypes:
   - Egress


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99492

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated DNS egress network rules to explicitly allow TCP and UDP traffic on port **5353**.
  * Improved DNS resolution compatibility by switching from named/non-numeric DNS port entries to the standard numeric **5353** port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->