### PR TITLE
OCPBUGS-105391: Pass management cluster proxy env vars to CSI driver operator deployments

### DIFF
--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller.go
@@ -147,6 +147,8 @@ func (c *HyperShiftDeploymentController) Sync(ctx context.Context, syncCtx facto
 		return fmt.Errorf("failed to inject proxy data into deployment: %w", err)
 	}
 
+	injectMgmtProxyEnvVars(requiredCopy)
+
 	// The existence of the environment variable, ARO_HCP_SECRET_PROVIDER_CLASS_FOR_FILE, means this is an ARO HCP
 	// deployment. We need to pass along additional environment variables for ARO HCP in order to mount the backing
 	// certificates, related to the client IDs, in a volume on the azure-disk-csi-controller and
@@ -442,4 +444,16 @@ func (c *HyperShiftDeploymentController) applyRunAsUserIfSet(deployment *appsv1.
 	deployment.Spec.Template.Spec.SecurityContext.RunAsUser = &runAsUserValue
 
 	return nil
+}
+
+// injectMgmtProxyEnvVars injects management cluster proxy env vars into all containers of the deployment.
+func injectMgmtProxyEnvVars(deployment *appsv1.Deployment) {
+	for _, envName := range []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
+		if val := os.Getenv(envName); val != "" {
+			for i := range deployment.Spec.Template.Spec.Containers {
+				c := &deployment.Spec.Template.Spec.Containers[i]
+				c.Env = append(c.Env, corev1.EnvVar{Name: envName, Value: val})
+			}
+		}
+	}
 }

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
@@ -6,6 +6,8 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -95,6 +97,114 @@ func TestTLSSettingsFromHCP(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantMinVersion, gotVersion)
 			assert.Equal(t, tt.wantCiphers, gotCiphers)
+		})
+	}
+}
+
+func findEnvVar(name string, envVars []corev1.EnvVar) *corev1.EnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}
+
+func testDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "aws-ebs-csi-driver-operator",
+							Env: []corev1.EnvVar{
+								{Name: "DRIVER_IMAGE", Value: "quay.io/openshift/origin-aws-ebs-csi-driver:latest"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestInjectMgmtProxyEnvVars(t *testing.T) {
+	tests := []struct {
+		name       string
+		httpProxy  string
+		httpsProxy string
+		noProxy    string
+		validate   func(*testing.T, *appsv1.Deployment)
+	}{
+		{
+			name:       "all proxy env vars are set",
+			httpProxy:  "http://proxy.example.com:8080",
+			httpsProxy: "https://proxy.example.com:8443",
+			noProxy:    "localhost,127.0.0.1",
+			validate: func(t *testing.T, deployment *appsv1.Deployment) {
+				c := &deployment.Spec.Template.Spec.Containers[0]
+
+				httpProxy := findEnvVar("HTTP_PROXY", c.Env)
+				assert.NotNil(t, httpProxy)
+				assert.Equal(t, "http://proxy.example.com:8080", httpProxy.Value)
+
+				httpsProxy := findEnvVar("HTTPS_PROXY", c.Env)
+				assert.NotNil(t, httpsProxy)
+				assert.Equal(t, "https://proxy.example.com:8443", httpsProxy.Value)
+
+				noProxy := findEnvVar("NO_PROXY", c.Env)
+				assert.NotNil(t, noProxy)
+				assert.Equal(t, "localhost,127.0.0.1", noProxy.Value)
+
+				assert.NotNil(t, findEnvVar("DRIVER_IMAGE", c.Env), "existing env vars should be preserved")
+			},
+		},
+		{
+			name:      "only HTTP_PROXY is set",
+			httpProxy: "http://proxy.example.com:8080",
+			validate: func(t *testing.T, deployment *appsv1.Deployment) {
+				c := &deployment.Spec.Template.Spec.Containers[0]
+
+				assert.NotNil(t, findEnvVar("HTTP_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("HTTPS_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("NO_PROXY", c.Env))
+			},
+		},
+		{
+			name:       "only HTTPS_PROXY is set",
+			httpsProxy: "https://proxy.example.com:8443",
+			validate: func(t *testing.T, deployment *appsv1.Deployment) {
+				c := &deployment.Spec.Template.Spec.Containers[0]
+
+				assert.Nil(t, findEnvVar("HTTP_PROXY", c.Env))
+				assert.NotNil(t, findEnvVar("HTTPS_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("NO_PROXY", c.Env))
+			},
+		},
+		{
+			name: "no proxy env vars are set",
+			validate: func(t *testing.T, deployment *appsv1.Deployment) {
+				c := &deployment.Spec.Template.Spec.Containers[0]
+
+				assert.Nil(t, findEnvVar("HTTP_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("HTTPS_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("NO_PROXY", c.Env))
+
+				assert.NotNil(t, findEnvVar("DRIVER_IMAGE", c.Env), "existing env vars should be preserved")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HTTP_PROXY", tt.httpProxy)
+			t.Setenv("HTTPS_PROXY", tt.httpsProxy)
+			t.Setenv("NO_PROXY", tt.noProxy)
+
+			deployment := testDeployment()
+			injectMgmtProxyEnvVars(deployment)
+			tt.validate(t, deployment)
 		})
 	}
 }

--- a/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
+++ b/pkg/operator/csidriveroperator/hypershift_deployment_controller_test.go
@@ -183,6 +183,17 @@ func TestInjectMgmtProxyEnvVars(t *testing.T) {
 			},
 		},
 		{
+			name:    "only NO_PROXY is set",
+			noProxy: "localhost,127.0.0.1",
+			validate: func(t *testing.T, deployment *appsv1.Deployment) {
+				c := &deployment.Spec.Template.Spec.Containers[0]
+
+				assert.Nil(t, findEnvVar("HTTP_PROXY", c.Env))
+				assert.Nil(t, findEnvVar("HTTPS_PROXY", c.Env))
+				assert.NotNil(t, findEnvVar("NO_PROXY", c.Env))
+			},
+		},
+		{
 			name: "no proxy env vars are set",
 			validate: func(t *testing.T, deployment *appsv1.Deployment) {
 				c := &deployment.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
 ## Summary

  - Extract proxy injection into `injectMgmtProxyEnvVars()` helper function in `HyperShiftDeploymentController`
  - Inject management cluster `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` env vars from `os.Getenv()` into all operand deployment containers
  - Add unit tests covering full proxy, partial proxy, and no-proxy scenarios

  ## Problem

When the management cluster requires a proxy for external access, the CSI driver operator deployments (e.g.`aws-ebs-csi-driver-operator`) created by `HyperShiftDeploymentController` do not receive proxy environment variables. Without these, the CSI driver operator cannot reach cloud APIs (e.g. `sts.us-east-1.amazonaws.com`), causing STS token timeouts and failing all PVC provisioning — 26+ conformance tests break.


  ## Fix

The new `injectMgmtProxyEnvVars()` function reads proxy env vars from `os.Getenv()` (management cluster proxy, inherited from CPO) and injects them into all containers of the operand deployment. This follows the same `os.Getenv()` pattern  already used for `ARO_HCP_SECRET_PROVIDER_CLASS_FOR_DISK`, `HYPERSHIFT_IMAGE`, and `RUN_AS_USER` in the same `Sync()` method. It is a no-op when no proxy is configured.

  This is step 2 of a 3-repo fix:
  1. **HyperShift CPO** (OCPBUGS-105282) — Inject proxy env vars into CSO deployment
  2. **cluster-storage-operator** (this PR) — Pass proxy env vars to operand deployments
  3. **csi-operator** (OCPBUGS-105392) — Add `withHyperShiftProxy` hook to inject proxy into CSI driver controller containers

  ## Test plan

  - [ ] Unit tests pass: `go test -race ./pkg/operator/csidriveroperator/... -v`
  - [ ] `make test` passes
  - [ ] `make verify` passes
  - [ ] Full end-to-end validation requires all 3 repos fixed and tested on a proxy-required management cluster

  ## JIRA

  - [OCPBUGS-105391](https://redhat.atlassian.net/browse/OCPBUGS-105391)
  - Related: [OCPBUGS-105282](https://redhat.atlassian.net/browse/OCPBUGS-105282),
  [OCPBUGS-105392](https://redhat.atlassian.net/browse/OCPBUGS-105392)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured deployment containers receive configured management-cluster proxy settings for HTTP, HTTPS, and excluded addresses.
  * Preserved existing container environment variables when proxy settings are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->