### PR TITLE
STOR-3011: Implement CSO upgrade check and Prometheus alerts for SELnuxMount readiness, updated runbook URL

### DIFF
--- a/manifests/12_prometheusrules.yaml
+++ b/manifests/12_prometheusrules.yaml
@@ -103,7 +103,7 @@ spec:
           description: |
             {{ $value | humanize }} pods in the cluster have a SELinux conflict that must be resolved before upgrade to the next OpenShift version.
             Query metric selinux_warning_controller_selinux_volume_conflict to list affected pods.
-          runbook_url: https://github.com/openshift/enhancements/blob/master/enhancements/storage/selinuxmount-ga-block-upgrade.md
+          runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-storage-operator/SELinuxMountGAReadinessWorkloadsDetected.md
     - name: kubernetes-storage
     # These alerts originate from https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/de834e9a291b49396125768f041e2078763f48b5/alerts/storage_alerts.libsonnet
       rules:

--- a/pkg/operator/selinuxmountreadiness/controller.go
+++ b/pkg/operator/selinuxmountreadiness/controller.go
@@ -22,8 +22,7 @@ const (
 	selinuxConflictsConfigMapName = "selinux-conflicts"
 	selinuxConflictsDataKey       = "conflictsPresent"
 
-	// KCSArticleURL is linked from Prometheus alerts. Update when the KCS article is published.
-	KCSArticleURL = "https://github.com/openshift/enhancements/blob/master/enhancements/storage/selinuxmount-ga-block-upgrade.md"
+	RunbookURL = "https://github.com/openshift/runbooks/blob/master/alerts/cluster-storage-operator/SELinuxMountGAReadinessWorkloadsDetected.md"
 )
 
 // Controller watches openshift-config/selinux-conflicts written by the
@@ -100,7 +99,7 @@ func upgradeBlockedMessage() string {
 		"Workloads incompatible with SELinuxMount GA were detected and could break after upgrade to the next release. "+
 			"See metric selinux_warning_controller_selinux_volume_conflict to list all affected pods. "+
 			"See %s for remediation.",
-		KCSArticleURL,
+		RunbookURL,
 	)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the SELinux mount readiness alert and upgrade-blocked message links to point to the correct OpenShift runbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->