### PR TITLE
OCPBUGS-91027: Add KAS-defaulted fields to storage-operator ValidatingAdmissionPolicy manifests

### DIFF
--- a/manifests/13_validating_admission_policy.yaml
+++ b/manifests/13_validating_admission_policy.yaml
@@ -16,6 +16,10 @@ spec:
       apiVersions: ["v1"]
       operations: ["CREATE", "UPDATE"]
       resources: ["namespaces"]
+      scope: "*"
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
   variables:
   # Check if fsgroup policy label exists
   - name: hasFsGroupPolicyLabel

--- a/manifests/14_validating_admission_policy_binding.yaml
+++ b/manifests/14_validating_admission_policy_binding.yaml
@@ -17,3 +17,7 @@ spec:
       apiVersions: ["v1"]
       operations: ["CREATE", "UPDATE"]
       resources: ["namespaces"]
+      scope: "*"
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}


### PR DESCRIPTION
The API server auto-injects default fields into the storage-operator's ValidatingAdmissionPolicy manifests, causing the CVO to detect a perpetual diff and hot-loop Update calls every 3–4.5 minutes.

Adds matchPolicy, namespaceSelector, objectSelector, and scope to 13_validating_admission_policy.yaml and 14_validating_admission_policy_binding.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Validation policies now apply consistently across all namespace scopes.
  * Equivalent API resources are matched consistently during admission checks.
  * Empty namespace and object selectors are explicitly supported, ensuring resources are evaluated without requiring additional selector configuration.
  * These updates provide more predictable policy enforcement across both namespaced and cluster-scoped resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->