### PR TITLE
GCP-958: temporarily disable GCP PD CSI driver in HyperShift path

### DIFF
--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -329,7 +329,9 @@ func (hsr *HyperShiftStarter) populateConfigs(clients *csoclients.Clients) []csi
 		csioperatorclient.GetAzureDiskCSIOperatorConfig(true),
 		csioperatorclient.GetAzureFileCSIOperatorConfig(true),
 		csioperatorclient.GetAWSEBSCSIOperatorConfig(true),
-		csioperatorclient.GetGCPPDCSIOperatorConfig(true),
+		// GCP PD HyperShift support is temporarily disabled: .
+		// Re-enable once openshift/hypershift#9450 (or its follow-ups) lands.
+		// csioperatorclient.GetGCPPDCSIOperatorConfig(true),
 		csioperatorclient.GetOpenStackManilaOperatorConfig(true, clients, hsr.eventRecorder),
 		csioperatorclient.GetOpenStackCinderCSIOperatorConfig(true),
 		csioperatorclient.GetPowerVSBlockCSIOperatorConfig(true),


### PR DESCRIPTION
## Summary

Temporarily disables the GCP PD CSI driver operator registration in `HyperShiftStarter.populateConfigs()`.

## Why

The HostedCluster/CVO-side wiring for the GCP PD CSI driver (CVO resource exclusion, and the control-plane sub-deployment image env var `GCP_PD_DRIVER_CONTROL_PLANE_IMAGE`) has not fully landed in `openshift/hypershift` yet:

- [openshift/hypershift#9450](https://github.com/openshift/hypershift/pull/9450) — full CPO/CVO wiring for the driver's control-plane sub-deployment (still open)

With [#728](https://github.com/openshift/cluster-storage-operator/pull/728) merged, CSO now activates the GCP PD driver operator on every GCP `HostedCluster` as soon as this image ships in the release payload. Since the HyperShift side isn't ready, the driver operator can never bring up its controller sub-Deployment (missing image + no GCP credentials), so it never reports `Available`, which hangs `ClusterVersion` on GCP e2e jobs.

## Change

Comment out `csioperatorclient.GetGCPPDCSIOperatorConfig(true)` in `HyperShiftStarter.populateConfigs()`. Standalone GCP PD support (`GetGCPPDCSIOperatorConfig(false)`) is untouched.

This should be reverted once the HyperShift-side wiring (#9450 or its follow-ups) merges.

## Test plan

- [x] `make build`
- [x] `make test-unit` (all packages pass, no existing test asserts driver membership in `HyperShiftStarter.populateConfigs()`)
- [x] Verify on a live HyperShift/GCP CI cluster that `gcp-pd-csi-driver-operator` is no longer started and `ClusterVersion` no longer hangs on GCP HostedClusters

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * HyperShift CSI configuration no longer enables the GCP Persistent Disk driver.
  * The driver remains temporarily disabled pending HyperShift support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->