### PR TITLE
GCP-958: re-enable GCP PD CSI driver in HyperShift path

### DIFF
--- a/pkg/operator/operator_starter.go
+++ b/pkg/operator/operator_starter.go
@@ -329,9 +329,7 @@ func (hsr *HyperShiftStarter) populateConfigs(clients *csoclients.Clients) []csi
 		csioperatorclient.GetAzureDiskCSIOperatorConfig(true),
 		csioperatorclient.GetAzureFileCSIOperatorConfig(true),
 		csioperatorclient.GetAWSEBSCSIOperatorConfig(true),
-		// GCP PD HyperShift support is temporarily disabled: .
-		// Re-enable once openshift/hypershift#9450 (or its follow-ups) lands.
-		// csioperatorclient.GetGCPPDCSIOperatorConfig(true),
+		csioperatorclient.GetGCPPDCSIOperatorConfig(true),
 		csioperatorclient.GetOpenStackManilaOperatorConfig(true, clients, hsr.eventRecorder),
 		csioperatorclient.GetOpenStackCinderCSIOperatorConfig(true),
 		csioperatorclient.GetPowerVSBlockCSIOperatorConfig(true),


### PR DESCRIPTION
## What

Re-registers the GCP PD CSI driver in `HyperShiftStarter.populateConfigs()` so CSO activates the driver operator on GCP HostedClusters again. This un-comments the single line that was temporarily disabled in #739 (commit `26ededa83`).

```diff
 		csioperatorclient.GetAWSEBSCSIOperatorConfig(true),
-		// GCP PD HyperShift support is temporarily disabled: .
-		// Re-enable once openshift/hypershift#9450 (or its follow-ups) lands.
-		// csioperatorclient.GetGCPPDCSIOperatorConfig(true),
+		csioperatorclient.GetGCPPDCSIOperatorConfig(true),
 		csioperatorclient.GetOpenStackManilaOperatorConfig(true, clients, hsr.eventRecorder),
```

## Why now

#739 disabled GCP PD on the HyperShift path because the HostedCluster/CVO-side wiring  had not yet landed in openshift/hypershift, and the csi-operator applied a set of prerequisite RBAC assets via the management-cluster client that it lacked permission for — which crash-looped the operator and hung ClusterVersion.

Both root causes are now addressed:
- The openshift/hypershift CVO-exclusion wiring has landed.
- The csi-operator prerequisite-assets fix is in (HyperShift path now applies only `controller_sa.yaml`).

## Verification

End-to-end dynamic provisioning was verified on a GCP HyperShift hosted cluster running a CSO build with GCP PD enabled:
- `storage` ClusterOperator `Available=True, Progressing=False, Degraded=False`
- `gcp-pd-csi-driver-node` DaemonSet running on all workers (3/3 per pod)
- PVC (`standard-csi`, `pd.csi.storage.gke.io`) → **Bound**; PV dynamically provisioned
- Backing GCP Persistent Disk created (`READY`, attached to the scheduled worker node)
- Test pod mounted the volume and successfully wrote and read back data
- ClusterVersion reached `Completed` / `Available=True`

This reverts the temporary disable from `26ededa83` ([GCP-958](https://redhat.atlassian.net/browse/GCP-958)). Standalone GCP PD support is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for the GCP Persistent Disk CSI operator in HyperShift.

- **Bug Fixes**
  - Restored the GCP Persistent Disk configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->